### PR TITLE
fix font flicker

### DIFF
--- a/src/components/appearance-settings.tsx
+++ b/src/components/appearance-settings.tsx
@@ -1,17 +1,27 @@
+import { useRouteContext, useRouter } from "@tanstack/react-router";
 import { Label } from "~/components/ui/label";
 import { Switch } from "~/components/ui/switch";
 import { TabsContent } from "~/components/ui/tabs";
+import { setAppFont } from "~/server-fns/app-font";
 import { useAppearanceStore } from "~/stores/appearance-store";
+import { AppFont } from "~/types";
 import TokenUsageByModel from "./token-usage-by-model";
 
 export default function AppearanceSettings() {
-	const enableAllMono = useAppearanceStore((store) => store.enableAllMono);
-	const toggleAllMono = useAppearanceStore((store) => store.toggleAllMono);
+	const { appFont } = useRouteContext({ from: "__root__" });
+	const router = useRouter();
 
 	const showTokenUsage = useAppearanceStore((store) => store.showTokenUsage);
 	const toggleShowTokenUsage = useAppearanceStore(
 		(store) => store.toggleShowTokenUsage,
 	);
+
+	const toggleFont = () => {
+		const updatedFont: AppFont =
+			appFont === "font-mono" ? "font-sans" : "font-mono";
+		// router.invalidate refreshes the route context
+		setAppFont({ data: updatedFont }).then(() => router.invalidate());
+	};
 
 	return (
 		<TabsContent className="flex flex-col gap-12" value="appearance">
@@ -34,9 +44,9 @@ export default function AppearanceSettings() {
 
 						<Switch
 							aria-label="Enable mono font"
-							checked={enableAllMono}
+							checked={appFont === "font-mono"}
 							id="mono-font"
-							onCheckedChange={toggleAllMono}
+							onCheckedChange={toggleFont}
 						/>
 					</div>
 				</div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,7 +18,7 @@ import { authClient } from "~/lib/auth-client";
 import { getToken } from "~/lib/auth-server";
 import { cn } from "~/lib/utils";
 import { ChatProvider } from "~/providers/chat-provider";
-import { useAppearanceStore } from "~/stores/appearance-store";
+import { getAppFont } from "~/server-fns/app-font";
 import appCss from "~/styles.css?url";
 
 // Get auth information for SSR using available cookies
@@ -41,9 +41,12 @@ export const Route = createRootRouteWithContext<{
 			ctx.context.convexQueryClient.serverHttpClient?.setAuth(token);
 		}
 
+		const appFont = await getAppFont();
+
 		return {
 			isAuthenticated: !!token,
 			token,
+			appFont,
 		};
 	},
 	head: () => ({
@@ -95,14 +98,14 @@ function RootComponent() {
 }
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
-	const enableAllMono = useAppearanceStore((store) => store.enableAllMono);
+	const { appFont } = Route.useRouteContext();
 
 	return (
 		<html lang="en">
 			<head>
 				<HeadContent />
 			</head>
-			<body className={cn("overflow-hidden", enableAllMono ? "font-mono" : "")}>
+			<body className={cn("overflow-hidden", appFont)}>
 				<NextThemesProvider
 					attribute="class"
 					defaultTheme="system"

--- a/src/server-fns/app-font.ts
+++ b/src/server-fns/app-font.ts
@@ -1,0 +1,19 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getCookie, setCookie } from "@tanstack/react-start/server";
+import { AppFont } from "~/types";
+
+const fontStorageKey = "app-font";
+
+export const getAppFont = createServerFn().handler((): AppFont => {
+	const appFont = getCookie(fontStorageKey);
+	if (!appFont) {
+		return "font-sans";
+	}
+	return appFont as AppFont;
+});
+
+export const setAppFont = createServerFn()
+	.inputValidator((data: AppFont) => data)
+	.handler(({ data }) => {
+		setCookie(fontStorageKey, data);
+	});

--- a/src/stores/appearance-store.ts
+++ b/src/stores/appearance-store.ts
@@ -2,19 +2,14 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type AppearanceStoreState = {
-	enableAllMono: boolean;
 	showTokenUsage: boolean;
-	toggleAllMono: () => void;
 	toggleShowTokenUsage: () => void;
 };
 
 export const useAppearanceStore = create<AppearanceStoreState>()(
 	persist(
 		(set) => ({
-			enableAllMono: false,
 			showTokenUsage: false,
-			toggleAllMono: () =>
-				set((prev) => ({ ...prev, enableAllMono: !prev.enableAllMono })),
 			toggleShowTokenUsage: () =>
 				set((prev) => ({
 					...prev,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,3 +65,5 @@ export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 export type CustomUIMessage = Omit<UIMessage<MessageMetadata>, "role"> & {
 	role: "user" | "assistant";
 };
+
+export type AppFont = "font-mono" | "font-sans";


### PR DESCRIPTION
Closes #12 
Courtesy - @josefbender (https://www.youtube.com/watch?v=h8QJ-keNnHw)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes font flicker by moving the font preference to a server cookie and applying the correct font class during SSR. Updates the Appearance settings to toggle font via a server call and removes the client-only font flag.

- **Bug Fixes**
  - Added getAppFont/setAppFont server fns to persist font in a cookie.
  - Loaded appFont in the root loader and applied it to the body class on SSR.
  - Replaced Zustand’s enableAllMono toggle with server-driven toggle using router.invalidate.

<sup>Written for commit c06c3ee63a7c3a212ee489752328c30e10a3e18a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

