### PR TITLE
fix settings tab

### DIFF
--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -46,7 +46,7 @@ function SettingsPage() {
 
 					<Tabs className="w-full flex-col" defaultValue="apiKeys">
 						{/* Scrollable tabs on mobile */}
-						<div className="w-full overflow-x-auto lg:w-fit">
+						<div className="scrollbar-hide w-full overflow-x-auto lg:w-fit">
 							<TabsList className="grid w-full min-w-fit grid-cols-4 lg:w-auto">
 								<TabsTrigger
 									className="text-xs whitespace-nowrap sm:text-sm"

--- a/src/styles.css
+++ b/src/styles.css
@@ -185,6 +185,14 @@
 	.shadcn-dropdown-item {
 		@apply data-[variant=destructive]:*:[svg]:text-destructive! relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-2.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-8 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0;
 	}
+
+	.scrollbar-hide {
+		-ms-overflow-style: none;
+		scrollbar-width: none;
+	}
+	.scrollbar-hide::-webkit-scrollbar {
+		display: none;
+	}
 }
 
 code,


### PR DESCRIPTION
Closes #33 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a scrollbar-hide utility and applied it to the Settings tabs wrapper to remove the visible horizontal scrollbar while preserving horizontal scroll. Fixes the mobile UI overflow in the Settings tab.

<sup>Written for commit 8418da264117ce9de2deeb397eacab8a25f2b694. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

