### PR TITLE
fix prompt input

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -89,7 +89,7 @@ export default function Chat({
 	}, [setMessages, dbMessages]);
 
 	return (
-		<div className="relative mx-auto flex h-[calc(100svh-3.5rem)] max-h-[calc(100svh-3.5rem)] w-full flex-col md:h-svh md:max-h-svh">
+		<div className="relative mx-auto flex h-full min-h-0 w-full flex-col">
 			{/* Full height scroll area that extends behind the prompt */}
 			<div className="absolute inset-0">
 				{!isMessagesPending && messages.length === 0 && <EmptyChatContent />}

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -40,7 +40,7 @@ function RouteComponent() {
 	return (
 		<SidebarProvider>
 			<AppSidebar variant="inset" />
-			<SidebarInset>
+			<SidebarInset className="h-svh overflow-hidden">
 				<FloatingSidebarTrigger />
 				<Outlet />
 			</SidebarInset>


### PR DESCRIPTION
Closes #39 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat prompt input getting cut off by correcting container heights and overflow so the prompt stays pinned to the bottom. Closes #39.

- **Bug Fixes**
  - App shell: SidebarInset now uses h-svh and overflow-hidden to align with the viewport and prevent body scroll.
  - Chat: container switched to h-full and min-h-0 (removing calc vh heights) so the scroll area behaves and the prompt remains visible.

<sup>Written for commit d51aa92b4681b3d67dd5138044fdd2e853e50e8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

