### PR TITLE
add gpt 5.3 codex

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.47",
         "@ai-sdk/google": "^3.0.31",
-        "@ai-sdk/openai": "^3.0.33",
+        "@ai-sdk/openai": "^3.0.34",
         "@ai-sdk/react": "^3.0.102",
         "@ai-sdk/xai": "^3.0.59",
         "@base-ui/react": "^1.2.0",
@@ -73,7 +73,7 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.31", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-RVNz8WFSIRbXbYDBE6JvlE2escWPJimBCs22LzKEYH7DNfl/X7cHNa1LFho4PsY6Ib0JmbzB8s2+i0wHs/wNCg=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.33", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-O/8SVKAiwFHkGAUfBnrLb7L2IjbpP9ySWbmOktOfa0KtzutZkmKNrJ5CtB5dj+lwuENbOuZeRsnsZdOjar7hig=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.34", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rnSsjV7cqIUcYdHgTcXRvN+xn0+wv/DB/U1SCxCVOKDsD9xaNgDjQTuMeJ+dUTzpH4Gn+XS0dJQELCWVIFYQVg=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.30", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iTjumHf1/u4NhjXYFn/aONM2GId3/o7J1Lp5ql8FCbgIMyRwrmanR5xy1S3aaVkfTscuDvLTzWiy1mAbGzK3nQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"@ai-sdk/anthropic": "^3.0.47",
 		"@ai-sdk/google": "^3.0.31",
-		"@ai-sdk/openai": "^3.0.33",
+		"@ai-sdk/openai": "^3.0.34",
 		"@ai-sdk/react": "^3.0.102",
 		"@ai-sdk/xai": "^3.0.59",
 		"@base-ui/react": "^1.2.0",

--- a/src/constants/model-providers.ts
+++ b/src/constants/model-providers.ts
@@ -134,6 +134,12 @@ const openAiModels = {
 			modelId: "gpt-5.2",
 			isFree: false,
 		},
+		{
+			name: "GPT 5.3 Codex",
+			openRouterModelId: "openai/gpt-5.3-codex",
+			modelId: "gpt-5.3-codex",
+			isFree: false,
+		},
 	],
 };
 


### PR DESCRIPTION
Closes #41 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added support for GPT 5.3 Codex in the OpenAI model list so users can select it in the app.

- **New Features**
  - Added GPT 5.3 Codex (modelId: gpt-5.3-codex, openRouterModelId: openai/gpt-5.3-codex). Marked as non-free.

- **Dependencies**
  - Bumped @ai-sdk/openai from 3.0.33 to 3.0.34.

<sup>Written for commit 4c55be332e9bbcd7516db586b5696a0cb7b58950. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

