### PR TITLE
fix sidebar chat item

### DIFF
--- a/src/components/app-sidebar-chat-item.tsx
+++ b/src/components/app-sidebar-chat-item.tsx
@@ -32,7 +32,7 @@ export default function AppSidebarChatItem({ chat }: Props) {
 				onClick={handleClick}
 				params={{ chatId: chat.uuid }}
 				to="/chat/$chatId"
-				className="flex w-full pr-8 md:pr-7"
+				className="flex w-full"
 			>
 				<SidebarMenuButton
 					isActive={isActive}
@@ -46,6 +46,7 @@ export default function AppSidebarChatItem({ chat }: Props) {
 				</SidebarMenuButton>
 			</Link>
 			<div
+				data-sidebar="menu-action"
 				className={
 					isMobile
 						? "absolute top-1/2 right-1 z-30 flex h-9 w-9 -translate-y-1/2 items-center justify-center"

--- a/src/components/app-sidebar-folder-item.tsx
+++ b/src/components/app-sidebar-folder-item.tsx
@@ -29,7 +29,7 @@ export default function AppSidebarFolderItem(props: Props) {
 				<SidebarMenuButton
 					onClick={handleClick}
 					tooltip={props.folder.title}
-					className="w-full pr-8 md:pr-7"
+					className="w-full"
 				>
 					<AppSidebarFolderItemToggler
 						folderHasChats={props.folder.chats.length > 0}
@@ -40,6 +40,7 @@ export default function AppSidebarFolderItem(props: Props) {
 					</span>
 				</SidebarMenuButton>
 				<div
+					data-sidebar="menu-action"
 					className={
 						isMobile
 							? "absolute top-1/2 right-1 z-30 flex h-9 w-9 -translate-y-1/2 items-center justify-center"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed sidebar chat and folder item alignment and click behavior. Removed extra right padding for full‑width buttons and added data-sidebar="menu-action" so action clicks don’t trigger navigation, especially on mobile.

<sup>Written for commit dd331382951f0ffd9a47879fd0d0213069c2e7a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

