### PR TITLE
fix skeleton flicker during transition

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -85,8 +85,12 @@ export default function Chat({
 	}, [messages]);
 
 	useEffect(() => {
-		setMessages(dbMessages);
-	}, [setMessages, dbMessages]);
+		// Only sync dbMessages when we have actual data, not during initial load
+		// This preserves optimistic messages during route transitions
+		if (!isMessagesPending) {
+			setMessages(dbMessages);
+		}
+	}, [setMessages, dbMessages, isMessagesPending]);
 
 	return (
 		<div className="relative mx-auto flex h-full min-h-0 w-full flex-col">
@@ -101,7 +105,7 @@ export default function Chat({
 								className="pb-safe my-4 space-y-6 lg:my-8 lg:space-y-8"
 								style={{ paddingBottom: `${inputHeight + 40}px` }}
 							>
-								{isMessagesPending ? (
+								{isMessagesPending && messages.length === 0 ? (
 									<>
 										<UserMessageSkeleton />
 										<AssistantMessageSkeleton />

--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -62,33 +62,15 @@ export default function UserPromptInput(props: Props) {
 			return;
 		}
 
-		if (!paramsChatId) {
-			navigate({
-				to: "/chat/$chatId",
-				params: { chatId: props.chatId },
-			});
-			const dbGeneratedChatId = await createChatMutation.mutateAsync({
-				uuid: props.chatId,
-			});
-			handleChatTitleUpdate(dbGeneratedChatId);
-		}
-
 		const sourceMessageId = generateRandomUUID();
+		const messageText = input;
 
-		createMessageMutation.mutate({
-			messageBody: {
-				chatId: props.chatId,
-				role: "user",
-				sourceMessageId,
-				parts: JSON.stringify([{ type: "text", text: input }]),
-			},
-		});
-
+		// Send message optimistically BEFORE navigation so it's in state
 		props.sendMessage(
 			{
 				role: "user",
 				id: sourceMessageId,
-				parts: [{ type: "text", text: input }],
+				parts: [{ type: "text", text: messageText }],
 			},
 			{
 				body: {
@@ -101,7 +83,30 @@ export default function UserPromptInput(props: Props) {
 			},
 		);
 
+		// Clear input immediately for better UX
 		setInput("");
+
+		if (!paramsChatId) {
+			// Navigate to chat page after optimistic message is sent
+			navigate({
+				to: "/chat/$chatId",
+				params: { chatId: props.chatId },
+			});
+			const dbGeneratedChatId = await createChatMutation.mutateAsync({
+				uuid: props.chatId,
+			});
+			handleChatTitleUpdate(dbGeneratedChatId);
+		}
+
+		// Persist message to database
+		createMessageMutation.mutate({
+			messageBody: {
+				chatId: props.chatId,
+				role: "user",
+				sourceMessageId,
+				parts: JSON.stringify([{ type: "text", text: messageText }]),
+			},
+		});
 	};
 
 	const resizeTextarea = () => {


### PR DESCRIPTION
Closes #59 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skeleton flicker during chat route transitions by preserving optimistic messages and only showing skeletons on initial load. Closes #59.

- **Bug Fixes**
  - Defer syncing `dbMessages` until loading completes to avoid overwriting optimistic messages; send the user message before navigation and clear input immediately, then persist to DB.
  - Render skeletons only when `isMessagesPending` and no messages are in state.

<sup>Written for commit e7b2da6468884cf45277bebfd63f04eda990d491. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

