### PR TITLE
Upload files and chat

### DIFF
--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
 
-export const getImageUrl = query({
+const getStorageUrl = query({
 	args: {
 		storageId: v.id("_storage"),
 	},
@@ -9,3 +9,6 @@ export const getImageUrl = query({
 		return ctx.storage.getUrl(args.storageId);
 	},
 });
+
+export const getFileUrl = getStorageUrl;
+export const getImageUrl = getStorageUrl;

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,11 +1,33 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
+import { getAuthUserIdOrThrow } from "./model/users";
 
 const getStorageUrl = query({
 	args: {
 		storageId: v.id("_storage"),
 	},
 	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		const image = await ctx.db
+			.query("imageGenerations")
+			.withIndex("by_storage_id", (q) => q.eq("storageId", args.storageId))
+			.first();
+
+		// Generated images are owned through the gallery table.
+		if (image?.userId === userId) {
+			return ctx.storage.getUrl(args.storageId);
+		}
+
+		const uploadedFile = await ctx.db
+			.query("uploadedFiles")
+			.withIndex("by_storage_id", (q) => q.eq("storageId", args.storageId))
+			.first();
+
+		// Prompt attachments are owned through uploadedFiles.
+		if (uploadedFile?.userId !== userId) {
+			throw new Error("Unauthorized access");
+		}
+
 		return ctx.storage.getUrl(args.storageId);
 	},
 });

--- a/convex/imageGenerations.ts
+++ b/convex/imageGenerations.ts
@@ -18,16 +18,24 @@ export const getAll = query({
 export const create = mutation({
 	args: {
 		storageId: v.id("_storage"),
-		generatedImageUrl: v.string(),
+		generatedImageUrl: v.optional(v.string()),
 	},
 	handler: async (ctx, args) => {
 		const authUserId = await getAuthUserIdOrThrow(ctx);
+		// Allow callers to omit the URL and derive it from storage after upload.
+		const generatedImageUrl =
+			args.generatedImageUrl ?? (await ctx.storage.getUrl(args.storageId));
+		if (!generatedImageUrl) {
+			throw new Error("Could not generate image URL");
+		}
 
 		await ctx.db.insert("imageGenerations", {
 			userId: authUserId,
 			storageId: args.storageId,
-			generatedImageUrl: args.generatedImageUrl,
+			generatedImageUrl,
 		});
+
+		return generatedImageUrl;
 	},
 });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -10,7 +10,13 @@ import {
 import { getAuthUserIdOrThrow } from "./model/users";
 
 const hydrateStoredFileParts = async (ctx: QueryCtx, parts: string) => {
-	const parsedParts = JSON.parse(parts);
+	let parsedParts: unknown;
+	try {
+		parsedParts = JSON.parse(parts);
+	} catch {
+		// Keep malformed legacy data readable instead of failing the whole query.
+		return parts;
+	}
 
 	if (!Array.isArray(parsedParts)) {
 		return parts;
@@ -127,6 +133,36 @@ export const createMessage = mutation({
 	},
 	handler: async (ctx, args) => {
 		const userId = await getAuthUserIdOrThrow(ctx);
+		let parsedParts: unknown;
+		try {
+			parsedParts = JSON.parse(args.messageBody.parts);
+		} catch {
+			parsedParts = null;
+		}
+
+		if (Array.isArray(parsedParts)) {
+			for (const part of parsedParts) {
+				const storageId = part?.providerMetadata?.convex?.storageId;
+				if (typeof storageId !== "string") {
+					continue;
+				}
+
+				// Record attachment ownership once so URL lookups can authorize by storageId.
+				const existingFile = await ctx.db
+					.query("uploadedFiles")
+					.withIndex("by_storage_id", (q) =>
+						q.eq("storageId", storageId as any),
+					)
+					.first();
+
+				if (!existingFile) {
+					await ctx.db.insert("uploadedFiles", {
+						userId,
+						storageId: storageId as any,
+					});
+				}
+			}
+		}
 
 		await ctx.db.insert("messages", {
 			sourceMessageId: args.messageBody.sourceMessageId,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { MessageMetadata } from "~/types";
 import { internal } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
 import {
 	type QueryCtx,
 	internalMutation,
@@ -38,7 +39,7 @@ const hydrateStoredFileParts = async (ctx: QueryCtx, parts: string) => {
 				return part;
 			}
 
-			const freshUrl = await ctx.storage.getUrl(storageId as any);
+			const freshUrl = await ctx.storage.getUrl(storageId as Id<"_storage">);
 			if (!freshUrl) {
 				return part;
 			}
@@ -151,14 +152,14 @@ export const createMessage = mutation({
 				const existingFile = await ctx.db
 					.query("uploadedFiles")
 					.withIndex("by_storage_id", (q) =>
-						q.eq("storageId", storageId as any),
+						q.eq("storageId", storageId as Id<"_storage">),
 					)
 					.first();
 
 				if (!existingFile) {
 					await ctx.db.insert("uploadedFiles", {
 						userId,
-						storageId: storageId as any,
+						storageId: storageId as Id<"_storage">,
 					});
 				}
 			}

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,8 +1,51 @@
 import { v } from "convex/values";
 import { MessageMetadata } from "~/types";
 import { internal } from "./_generated/api";
-import { internalMutation, mutation, query } from "./_generated/server";
+import {
+	type QueryCtx,
+	internalMutation,
+	mutation,
+	query,
+} from "./_generated/server";
 import { getAuthUserIdOrThrow } from "./model/users";
+
+const hydrateStoredFileParts = async (ctx: QueryCtx, parts: string) => {
+	const parsedParts = JSON.parse(parts);
+
+	if (!Array.isArray(parsedParts)) {
+		return parts;
+	}
+
+	const hydratedParts = await Promise.all(
+		parsedParts.map(async (part) => {
+			if (
+				!part ||
+				typeof part !== "object" ||
+				part.type !== "file" ||
+				typeof part.url !== "string"
+			) {
+				return part;
+			}
+
+			const storageId = part.providerMetadata?.convex?.storageId;
+			if (typeof storageId !== "string") {
+				return part;
+			}
+
+			const freshUrl = await ctx.storage.getUrl(storageId as any);
+			if (!freshUrl) {
+				return part;
+			}
+
+			return {
+				...part,
+				url: freshUrl,
+			};
+		}),
+	);
+
+	return JSON.stringify(hydratedParts);
+};
 
 export const getMessages = query({
 	args: { chatId: v.string() },
@@ -17,7 +60,12 @@ export const getMessages = query({
 			.order("asc")
 			.collect();
 
-		return messages.map(({ userId: _, ...rest }) => ({ ...rest }));
+		return Promise.all(
+			messages.map(async ({ userId: _, ...rest }) => ({
+				...rest,
+				parts: await hydrateStoredFileParts(ctx, rest.parts),
+			})),
+		);
 	},
 });
 
@@ -56,9 +104,12 @@ export const getSharedChatMessages = query({
 
 		return {
 			sharedChat,
-			messages: messages.map(({ userId: _, ...rest }) => ({
-				...rest,
-			})),
+			messages: await Promise.all(
+				messages.map(async ({ userId: _, ...rest }) => ({
+					...rest,
+					parts: await hydrateStoredFileParts(ctx, rest.parts),
+				})),
+			),
 			parentChatTitle: parentChat?.title,
 		};
 	},

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,4 +66,12 @@ export default defineSchema({
 	})
 		.index("by_user", ["userId"])
 		.index("by_storage_id", ["storageId"]),
+
+	// Ownership map for non-image files uploaded in prompts.
+	uploadedFiles: defineTable({
+		userId: v.id("users"),
+		storageId: v.id("_storage"),
+	})
+		.index("by_user", ["userId"])
+		.index("by_storage_id", ["storageId"]),
 });

--- a/src/components/file-attachments-preview.tsx
+++ b/src/components/file-attachments-preview.tsx
@@ -1,0 +1,122 @@
+import { FileIcon, FileTextIcon, XIcon } from "@phosphor-icons/react";
+import type { FileUIPart } from "ai";
+import { cn } from "~/lib/utils";
+import { Button } from "./ui/button";
+
+type AttachmentPart = FileUIPart & { size?: number };
+
+type Props = {
+	attachments: AttachmentPart[];
+	className?: string;
+	onRemove?: (index: number) => void;
+};
+
+const isImageAttachment = (attachment: AttachmentPart) =>
+	attachment.mediaType.startsWith("image/");
+
+const formatFileSize = (size?: number) => {
+	if (size == null || Number.isNaN(size)) {
+		return null;
+	}
+
+	if (size < 1024) {
+		return `${size} B`;
+	}
+
+	if (size < 1024 * 1024) {
+		return `${(size / 1024).toFixed(1)} KB`;
+	}
+
+	return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const getAttachmentLabel = (attachment: AttachmentPart) =>
+	attachment.filename?.trim() || "Untitled file";
+
+export default function FileAttachmentsPreview({
+	attachments,
+	className,
+	onRemove,
+}: Props) {
+	if (attachments.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className={cn("grid grid-cols-1 gap-2 sm:grid-cols-2", className)}>
+			{attachments.map((attachment, index) => {
+				const label = getAttachmentLabel(attachment);
+				const fileSize = formatFileSize(attachment.size);
+
+				if (isImageAttachment(attachment)) {
+					return (
+						<div
+							className="group/attachment relative overflow-hidden rounded-2xl border border-border/70 bg-muted/40 shadow-sm"
+							key={`${attachment.url}-${index}`}
+						>
+							<img
+								alt={label}
+								className="h-28 w-full object-cover"
+								src={attachment.url}
+							/>
+							<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/80 to-transparent px-3 pt-8 pb-3">
+								<div className="truncate text-[11px] font-medium">{label}</div>
+								<div className="mt-0.5 text-[10px] text-muted-foreground">
+									{fileSize ?? "Image"}
+								</div>
+							</div>
+							{onRemove && (
+								<Button
+									aria-label={`Remove ${label}`}
+									className="absolute top-2 right-2 rounded-full bg-background/85 shadow-sm backdrop-blur"
+									onClick={() => onRemove(index)}
+									size="icon-xs"
+									type="button"
+									variant="outline"
+								>
+									<XIcon />
+								</Button>
+							)}
+						</div>
+					);
+				}
+
+				return (
+					<div
+						className="relative flex min-h-20 items-center gap-3 rounded-2xl border border-border/70 bg-linear-to-br from-muted/55 to-muted/15 px-3 py-3 shadow-sm"
+						key={`${attachment.url}-${index}`}
+					>
+						<div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80">
+							{attachment.mediaType.startsWith("text/") ? (
+								<FileTextIcon className="text-muted-foreground" />
+							) : attachment.mediaType === "application/pdf" ? (
+								<FileTextIcon className="text-muted-foreground" />
+							) : (
+								<FileIcon className="text-muted-foreground" />
+							)}
+						</div>
+						<div className="min-w-0 flex-1">
+							<div className="truncate text-xs font-medium">{label}</div>
+							<div className="mt-1 flex items-center gap-2 text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
+								<span>{attachment.mediaType || "file"}</span>
+								{fileSize && <span>{fileSize}</span>}
+							</div>
+						</div>
+						{onRemove && (
+							<Button
+								aria-label={`Remove ${label}`}
+								className="absolute top-2 right-2 rounded-full"
+								onClick={() => onRemove(index)}
+								size="icon-xs"
+								type="button"
+								variant="ghost"
+							>
+								<XIcon />
+							</Button>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/components/file-attachments-preview.tsx
+++ b/src/components/file-attachments-preview.tsx
@@ -1,4 +1,9 @@
-import { FileIcon, FileTextIcon, XIcon } from "@phosphor-icons/react";
+import {
+	FileIcon,
+	FilePdfIcon,
+	FileTextIcon,
+	XIcon,
+} from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
 import { cn } from "~/lib/utils";
 import { Button } from "./ui/button";
@@ -32,6 +37,18 @@ const formatFileSize = (size?: number) => {
 
 const getAttachmentLabel = (attachment: AttachmentPart) =>
 	attachment.filename?.trim() || "Untitled file";
+
+const getAttachmentTypeLabel = (attachment: AttachmentPart) => {
+	if (attachment.mediaType === "application/pdf") {
+		return "PDF";
+	}
+
+	if (attachment.mediaType.startsWith("text/")) {
+		return "TEXT";
+	}
+
+	return "FILE";
+};
 
 export default function FileAttachmentsPreview({
 	attachments,
@@ -90,7 +107,7 @@ export default function FileAttachmentsPreview({
 							{attachment.mediaType.startsWith("text/") ? (
 								<FileTextIcon className="text-muted-foreground" />
 							) : attachment.mediaType === "application/pdf" ? (
-								<FileTextIcon className="text-muted-foreground" />
+								<FilePdfIcon className="text-muted-foreground" />
 							) : (
 								<FileIcon className="text-muted-foreground" />
 							)}
@@ -98,7 +115,7 @@ export default function FileAttachmentsPreview({
 						<div className="min-w-0 flex-1">
 							<div className="truncate text-xs font-medium">{label}</div>
 							<div className="mt-1 flex items-center gap-2 text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
-								<span>{attachment.mediaType || "file"}</span>
+								<span>{getAttachmentTypeLabel(attachment)}</span>
 								{fileSize && <span>{fileSize}</span>}
 							</div>
 						</div>

--- a/src/components/input-upload-button.tsx
+++ b/src/components/input-upload-button.tsx
@@ -1,0 +1,50 @@
+import { SpinnerIcon, PaperclipIcon } from "@phosphor-icons/react";
+import { cn } from "~/lib/utils";
+import { Button } from "./ui/button";
+
+type Props = {
+	attachmentCount?: number;
+	disabled?: boolean;
+	isUploading?: boolean;
+	onAttachClick?: () => void;
+};
+
+export default function InputUploadButton({
+	attachmentCount,
+	disabled,
+	isUploading,
+	onAttachClick,
+}: Props) {
+	return (
+		<Button
+			className={cn(
+				"transition-all duration-300 ease-out",
+				attachmentCount &&
+					attachmentCount > 0 &&
+					"border-primary/60 bg-primary/8 text-foreground",
+			)}
+			disabled={disabled}
+			onClick={onAttachClick}
+			type="button"
+			variant="outline"
+		>
+			{isUploading ? (
+				<>
+					<SpinnerIcon className="size-4 animate-spin" />
+					<span>Uploading...</span>
+				</>
+			) : (
+				<>
+					<PaperclipIcon />
+					<span className="hidden sm:inline">Upload</span>
+					<span className="sm:hidden">File</span>
+				</>
+			)}
+			{!isUploading && attachmentCount && attachmentCount > 0 && (
+				<span className="rounded-full bg-foreground px-1.5 py-0.5 text-[10px] leading-none text-background">
+					{attachmentCount}
+				</span>
+			)}
+		</Button>
+	);
+}

--- a/src/components/input-upload-button.tsx
+++ b/src/components/input-upload-button.tsx
@@ -15,13 +15,13 @@ export default function InputUploadButton({
 	isUploading,
 	onAttachClick,
 }: Props) {
+	const hasAttachments = (attachmentCount ?? 0) > 0;
+
 	return (
 		<Button
 			className={cn(
 				"transition-all duration-300 ease-out",
-				attachmentCount &&
-					attachmentCount > 0 &&
-					"border-primary/60 bg-primary/8 text-foreground",
+				hasAttachments && "border-primary/60 bg-primary/8 text-foreground",
 			)}
 			disabled={disabled}
 			onClick={onAttachClick}
@@ -40,7 +40,7 @@ export default function InputUploadButton({
 					<span className="sm:hidden">File</span>
 				</>
 			)}
-			{!isUploading && attachmentCount && attachmentCount > 0 && (
+			{!isUploading && hasAttachments && (
 				<span className="rounded-full bg-foreground px-1.5 py-0.5 text-[10px] leading-none text-background">
 					{attachmentCount}
 				</span>

--- a/src/components/prompt-actions.tsx
+++ b/src/components/prompt-actions.tsx
@@ -1,5 +1,6 @@
 import {
 	GlobeIcon,
+	PaperclipIcon,
 	PaperPlaneRightIcon,
 	StopIcon,
 } from "@phosphor-icons/react";
@@ -13,11 +14,20 @@ import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type Props = {
+	attachmentCount?: number;
+	disabled?: boolean;
+	onAttachClick?: () => void;
 	status: ChatStatus;
 	stop: () => void;
 };
 
-export default function PromptActions({ status, stop }: Props) {
+export default function PromptActions({
+	attachmentCount = 0,
+	disabled = false,
+	onAttachClick,
+	status,
+	stop,
+}: Props) {
 	const isWebSearchEnabled = useModelStore((store) => store.isWebSearchEnabled);
 	const selectedModel = useModelStore((store) => store.selectedModel);
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
@@ -54,6 +64,27 @@ export default function PromptActions({ status, stop }: Props) {
 						<TooltipContent>Ctrl+Shift+S</TooltipContent>
 					</Tooltip>
 				)}
+
+				<Button
+					className={cn(
+						"transition-all duration-300 ease-out",
+						attachmentCount > 0 &&
+							"border-primary/60 bg-primary/8 text-foreground",
+					)}
+					disabled={disabled}
+					onClick={onAttachClick}
+					type="button"
+					variant="outline"
+				>
+					<PaperclipIcon />
+					<span className="hidden sm:inline">Upload</span>
+					<span className="sm:hidden">File</span>
+					{attachmentCount > 0 && (
+						<span className="rounded-full bg-foreground px-1.5 py-0.5 text-[10px] leading-none text-background">
+							{attachmentCount}
+						</span>
+					)}
+				</Button>
 			</div>
 
 			{status === "streaming" || status === "submitted" ? (

--- a/src/components/prompt-actions.tsx
+++ b/src/components/prompt-actions.tsx
@@ -1,18 +1,9 @@
-import {
-	GlobeIcon,
-	PaperclipIcon,
-	PaperPlaneRightIcon,
-	SpinnerIcon,
-	StopIcon,
-} from "@phosphor-icons/react";
-import { useHotkey } from "@tanstack/react-hotkeys";
+import { PaperPlaneRightIcon, StopIcon } from "@phosphor-icons/react";
 import type { ChatStatus } from "ai";
-import { cn } from "~/lib/utils";
-import { modelStoreActions, useModelStore } from "~/stores/model-store";
-import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
+import InputUploadButton from "./input-upload-button";
 import ModelSelector from "./model-selector";
 import { Button } from "./ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import WebSearchButton from "./web-search-button";
 
 type Props = {
 	attachmentCount?: number;
@@ -31,72 +22,19 @@ export default function PromptActions({
 	status,
 	stop,
 }: Props) {
-	const isWebSearchEnabled = useModelStore((store) => store.isWebSearchEnabled);
-	const selectedModel = useModelStore((store) => store.selectedModel);
-	const persistedUseOpenRouter = usePersistedApiKeysStore(
-		(store) => store.persistedUseOpenRouter,
-	);
-
-	useHotkey("Mod+Shift+S", modelStoreActions.toggleIsWebSearch);
-
 	return (
 		<div className="mt-3 flex flex-row items-center justify-between gap-2 lg:mt-4">
 			<div className="flex flex-1 flex-wrap items-center gap-2">
 				<ModelSelector />
 
-				{(selectedModel.openRouterModelId.startsWith("google") ||
-					persistedUseOpenRouter) && (
-					<Tooltip>
-						<TooltipTrigger
-							render={
-								<Button
-									className={cn(
-										"transition-all duration-300 ease-out",
-										isWebSearchEnabled ? "border-primary" : "border-border",
-									)}
-									onClick={modelStoreActions.toggleIsWebSearch}
-									type="button"
-									variant={isWebSearchEnabled ? "default" : "outline"}
-								>
-									<GlobeIcon />
-									<span className="hidden sm:inline">Search</span>
-									<span className="sm:hidden">Web</span>
-								</Button>
-							}
-						/>
-						<TooltipContent>Ctrl+Shift+S</TooltipContent>
-					</Tooltip>
-				)}
+				<WebSearchButton />
 
-				<Button
-					className={cn(
-						"transition-all duration-300 ease-out",
-						attachmentCount > 0 &&
-							"border-primary/60 bg-primary/8 text-foreground",
-					)}
+				<InputUploadButton
+					attachmentCount={attachmentCount}
 					disabled={disabled}
-					onClick={onAttachClick}
-					type="button"
-					variant="outline"
-				>
-					{isUploading ? (
-						<>
-							<SpinnerIcon className="size-4 animate-spin" />
-							<span>Uploading...</span>
-						</>
-					) : (
-						<>
-							<PaperclipIcon />
-							<span className="hidden sm:inline">Upload</span>
-							<span className="sm:hidden">File</span>
-						</>
-					)}
-					{!isUploading && attachmentCount > 0 && (
-						<span className="rounded-full bg-foreground px-1.5 py-0.5 text-[10px] leading-none text-background">
-							{attachmentCount}
-						</span>
-					)}
-				</Button>
+					isUploading={isUploading}
+					onAttachClick={onAttachClick}
+				/>
 			</div>
 
 			{status === "streaming" || status === "submitted" ? (

--- a/src/components/prompt-actions.tsx
+++ b/src/components/prompt-actions.tsx
@@ -2,6 +2,7 @@ import {
 	GlobeIcon,
 	PaperclipIcon,
 	PaperPlaneRightIcon,
+	SpinnerIcon,
 	StopIcon,
 } from "@phosphor-icons/react";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -16,6 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 type Props = {
 	attachmentCount?: number;
 	disabled?: boolean;
+	isUploading?: boolean;
 	onAttachClick?: () => void;
 	status: ChatStatus;
 	stop: () => void;
@@ -24,6 +26,7 @@ type Props = {
 export default function PromptActions({
 	attachmentCount = 0,
 	disabled = false,
+	isUploading = false,
 	onAttachClick,
 	status,
 	stop,
@@ -76,10 +79,19 @@ export default function PromptActions({
 					type="button"
 					variant="outline"
 				>
-					<PaperclipIcon />
-					<span className="hidden sm:inline">Upload</span>
-					<span className="sm:hidden">File</span>
-					{attachmentCount > 0 && (
+					{isUploading ? (
+						<>
+							<SpinnerIcon className="size-4 animate-spin" />
+							<span>Uploading...</span>
+						</>
+					) : (
+						<>
+							<PaperclipIcon />
+							<span className="hidden sm:inline">Upload</span>
+							<span className="sm:hidden">File</span>
+						</>
+					)}
+					{!isUploading && attachmentCount > 0 && (
 						<span className="rounded-full bg-foreground px-1.5 py-0.5 text-[10px] leading-none text-background">
 							{attachmentCount}
 						</span>

--- a/src/components/prompt-attachments-input.tsx
+++ b/src/components/prompt-attachments-input.tsx
@@ -28,6 +28,7 @@ export default function PromptAttachmentsInput({
 	return (
 		<>
 			<input
+				accept="image/*,application/pdf,text/*"
 				className="hidden"
 				multiple
 				onChange={onChange}

--- a/src/components/prompt-attachments-input.tsx
+++ b/src/components/prompt-attachments-input.tsx
@@ -1,0 +1,45 @@
+import type { FileUIPart } from "ai";
+import type { ChangeEvent, RefObject } from "react";
+import type { PendingAttachment } from "~/hooks/use-prompt-attachments";
+import FileAttachmentsPreview from "./file-attachments-preview";
+
+type Props = {
+	attachments: PendingAttachment[];
+	fileInputRef: RefObject<HTMLInputElement | null>;
+	onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+	onRemove: (index: number) => void;
+};
+
+export default function PromptAttachmentsInput({
+	attachments,
+	fileInputRef,
+	onChange,
+	onRemove,
+}: Props) {
+	const previewAttachments: Array<FileUIPart & { size?: number }> =
+		attachments.map((attachment) => ({
+			type: "file",
+			filename: attachment.filename,
+			mediaType: attachment.mediaType,
+			size: attachment.size,
+			url: attachment.previewUrl,
+		}));
+
+	return (
+		<>
+			<input
+				className="hidden"
+				multiple
+				onChange={onChange}
+				ref={fileInputRef}
+				type="file"
+			/>
+
+			<FileAttachmentsPreview
+				attachments={previewAttachments}
+				className="mb-3"
+				onRemove={onRemove}
+			/>
+		</>
+	);
+}

--- a/src/components/prompt-attachments-input.tsx
+++ b/src/components/prompt-attachments-input.tsx
@@ -10,6 +10,9 @@ type Props = {
 	onRemove: (index: number) => void;
 };
 
+const SUPPORTED_ATTACHMENT_ACCEPT =
+	"image/*,application/pdf,.c,.cc,.cpp,.cxx,.h,.hh,.hpp,.go,.js,.jsx,.ts,.tsx,.json,.md,.txt,.py,.java,.rs,.rb,.php,.css,.scss,.html,.xml,.yaml,.yml,.sh,.sql,.kt,.swift,.toml,.ini,.env";
+
 export default function PromptAttachmentsInput({
 	attachments,
 	fileInputRef,
@@ -28,7 +31,7 @@ export default function PromptAttachmentsInput({
 	return (
 		<>
 			<input
-				accept="image/*,application/pdf,text/*"
+				accept={SUPPORTED_ATTACHMENT_ACCEPT}
 				className="hidden"
 				multiple
 				onChange={onChange}

--- a/src/components/read-only-user-message.tsx
+++ b/src/components/read-only-user-message.tsx
@@ -1,7 +1,10 @@
 import { CopyIcon } from "@phosphor-icons/react";
 import type { Doc } from "convex/_generated/dataModel";
 import { toast } from "sonner";
+import { getFilePartsFromMessage } from "~/lib/get-file-parts-from-message";
 import { getMessageContentFromParts } from "~/lib/get-message-content-from-parts";
+import type { CustomUIMessage } from "~/types";
+import FileAttachmentsPreview from "./file-attachments-preview";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -10,13 +13,18 @@ type Props = {
 };
 
 export default function ReadOnlyUserMessage({ message }: Props) {
-	const messageContent = getMessageContentFromParts(JSON.parse(message.parts));
+	const parsedParts = JSON.parse(message.parts) as CustomUIMessage["parts"];
+	const messageAttachments = getFilePartsFromMessage(parsedParts);
+	const messageContent = getMessageContentFromParts(parsedParts);
 
 	return (
 		<div className="group flex w-full max-w-[90%] flex-col items-end space-y-3 self-end md:w-3/4">
 			{/* Message bubble */}
 			<div className="flex w-full max-w-full flex-col gap-6 rounded-lg border bg-popover px-4 py-4 text-sm wrap-break-word whitespace-pre-wrap">
-				<span className="whitespace-pre-wrap">{messageContent}</span>
+				<FileAttachmentsPreview attachments={messageAttachments} />
+				{messageContent.length > 0 && (
+					<span className="whitespace-pre-wrap">{messageContent}</span>
+				)}
 			</div>
 
 			{/* Copy button container */}

--- a/src/components/user-message.tsx
+++ b/src/components/user-message.tsx
@@ -7,12 +7,14 @@ import { memo, useState } from "react";
 import { toast } from "sonner";
 import { buildUserMessageParts } from "~/lib/build-user-message-parts";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
+import { getFilePartsFromMessage } from "~/lib/get-file-parts-from-message";
 import { getMessageContentFromParts } from "~/lib/get-message-content-from-parts";
 import { cn } from "~/lib/utils";
 import { useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage } from "~/types";
 import BranchOffButton from "./branch-off-button";
+import FileAttachmentsPreview from "./file-attachments-preview";
 import RetryModelDropdown from "./retry-model-dropdown";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -36,6 +38,7 @@ export default memo(function UserMessage({
 	nextMessage,
 }: Props) {
 	const messageContent = getMessageContentFromParts(message.parts);
+	const messageAttachments = getFilePartsFromMessage(message.parts);
 
 	const [isEditing, setIsEditing] = useState(false);
 
@@ -59,6 +62,7 @@ export default memo(function UserMessage({
 	const handleMessageEdit = (input: string) => {
 		const sourceMessageId = generateRandomUUID();
 		const userMessageParts = buildUserMessageParts({
+			attachments: messageAttachments,
 			latestGeneratedImageUrl,
 			model: selectedModel,
 			prompt: input,
@@ -118,7 +122,12 @@ export default memo(function UserMessage({
 						onSubmit={handleMessageEdit}
 					/>
 				) : (
-					<span className="whitespace-pre-wrap">{messageContent}</span>
+					<>
+						<FileAttachmentsPreview attachments={messageAttachments} />
+						{messageContent.length > 0 && (
+							<span className="whitespace-pre-wrap">{messageContent}</span>
+						)}
+					</>
 				)}
 			</div>
 			<div className="flex opacity-100 transition-opacity duration-200 md:opacity-0 md:group-hover:opacity-100">

--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -225,6 +225,7 @@ export default function UserPromptInput(props: Props) {
 						createChatMutation.isPending ||
 						createMessageMutation.isPending
 					}
+					isUploading={isUploading}
 					onAttachClick={() => fileInputRef.current?.click()}
 					status={props.status}
 					stop={props.stop}

--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -7,6 +7,7 @@ import { api } from "convex/_generated/api";
 import type { Id } from "convex/_generated/dataModel";
 import { useEffect, useRef, useState } from "react";
 import { useIsDesktop } from "~/hooks/use-desktop";
+import { usePromptAttachments } from "~/hooks/use-prompt-attachments";
 import { buildUserMessageParts } from "~/lib/build-user-message-parts";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { getChatTitle } from "~/server-fns/get-chat-title";
@@ -14,6 +15,7 @@ import { useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage } from "~/types";
 import PromptActions from "./prompt-actions";
+import PromptAttachmentsInput from "./prompt-attachments-input";
 
 type Props = {
 	chatId: string;
@@ -29,10 +31,12 @@ export default function UserPromptInput(props: Props) {
 	const { onHeightChange } = props;
 
 	const [input, setInput] = useState("");
+	const [isSubmittingPrompt, setIsSubmittingPrompt] = useState(false);
 
 	const navigate = useNavigate();
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
 	const isDesktop = useIsDesktop();
 	const selectedModel = useModelStore((store) => store.selectedModel);
 	const isWebSearchEnabled = useModelStore((store) => store.isWebSearchEnabled);
@@ -42,6 +46,14 @@ export default function UserPromptInput(props: Props) {
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
 		(store) => store.persistedUseOpenRouter,
 	);
+	const {
+		attachments,
+		clearAttachments,
+		handleAttachmentChange,
+		isUploading,
+		removeAttachment,
+		uploadAttachments,
+	} = usePromptAttachments();
 
 	const updateChatTitleMutation = useMutation({
 		mutationFn: useConvexMutation(api.chats.updateChatTitle),
@@ -54,6 +66,10 @@ export default function UserPromptInput(props: Props) {
 	});
 
 	const handleChatTitleUpdate = async (dbGeneratedChatId: Id<"chats">) => {
+		if (input.trim().length === 0) {
+			return;
+		}
+
 		const title = await getChatTitle({ data: { userMessage: input } });
 		await updateChatTitleMutation.mutateAsync({
 			chat: { chatId: dbGeneratedChatId, title: title as string },
@@ -61,60 +77,78 @@ export default function UserPromptInput(props: Props) {
 	};
 
 	const handlePromptSubmit = async () => {
-		if (!textareaRef.current?.value) {
+		if (
+			isSubmittingPrompt ||
+			(input.trim().length === 0 && attachments.length === 0)
+		) {
 			return;
 		}
 
-		const sourceMessageId = generateRandomUUID();
-		const messageText = input;
-		const userMessageParts = buildUserMessageParts({
-			latestGeneratedImageUrl: props.latestGeneratedImageUrl,
-			model: selectedModel,
-			prompt: messageText,
-		});
+		setIsSubmittingPrompt(true);
 
-		// Send message optimistically BEFORE navigation so it's in state
-		props.sendMessage(
-			{
-				role: "user",
-				id: sourceMessageId,
-				parts: userMessageParts,
-			},
-			{
-				body: {
-					model: selectedModel,
-					isWebSearchEnabled,
-					apiKeys: persistedApiKeys,
-					useOpenRouter: persistedUseOpenRouter,
-					chatId: props.chatId,
+		try {
+			const sourceMessageId = generateRandomUUID();
+			const messageText = input;
+			const { optimisticAttachments, persistedAttachments } =
+				await uploadAttachments();
+
+			const optimisticUserMessageParts = buildUserMessageParts({
+				attachments: optimisticAttachments,
+				latestGeneratedImageUrl: props.latestGeneratedImageUrl,
+				model: selectedModel,
+				prompt: messageText,
+			});
+			const persistedUserMessageParts = buildUserMessageParts({
+				attachments: persistedAttachments,
+				latestGeneratedImageUrl: props.latestGeneratedImageUrl,
+				model: selectedModel,
+				prompt: messageText,
+			});
+
+			props.sendMessage(
+				{
+					role: "user",
+					id: sourceMessageId,
+					parts: optimisticUserMessageParts,
 				},
-			},
-		);
+				{
+					body: {
+						model: selectedModel,
+						isWebSearchEnabled,
+						apiKeys: persistedApiKeys,
+						useOpenRouter: persistedUseOpenRouter,
+						chatId: props.chatId,
+					},
+				},
+			);
 
-		// Clear input immediately for better UX
-		setInput("");
+			setInput("");
+			clearAttachments();
 
-		if (!paramsChatId) {
-			// Navigate to chat page after optimistic message is sent
-			navigate({
-				to: "/chat/$chatId",
-				params: { chatId: props.chatId },
+			if (!paramsChatId) {
+				navigate({
+					to: "/chat/$chatId",
+					params: { chatId: props.chatId },
+				});
+				const dbGeneratedChatId = await createChatMutation.mutateAsync({
+					uuid: props.chatId,
+				});
+				handleChatTitleUpdate(dbGeneratedChatId);
+			}
+
+			createMessageMutation.mutate({
+				messageBody: {
+					chatId: props.chatId,
+					role: "user",
+					sourceMessageId,
+					parts: JSON.stringify(persistedUserMessageParts),
+				},
 			});
-			const dbGeneratedChatId = await createChatMutation.mutateAsync({
-				uuid: props.chatId,
-			});
-			handleChatTitleUpdate(dbGeneratedChatId);
+		} catch (error) {
+			console.error("Failed to submit prompt with attachments:", error);
+		} finally {
+			setIsSubmittingPrompt(false);
 		}
-
-		// Persist message to database
-		createMessageMutation.mutate({
-			messageBody: {
-				chatId: props.chatId,
-				role: "user",
-				sourceMessageId,
-				parts: JSON.stringify(userMessageParts),
-			},
-		});
 	};
 
 	const resizeTextarea = () => {
@@ -125,20 +159,17 @@ export default function UserPromptInput(props: Props) {
 		}
 	};
 
-	// Resize when the textarea value changes.
 	useEffect(() => {
 		resizeTextarea();
 	}, [input]);
 
-	// Measure and report height changes
 	useEffect(() => {
 		if (containerRef.current && onHeightChange) {
 			const height = containerRef.current.getBoundingClientRect().height;
 			onHeightChange(height);
 		}
-	}, [input, onHeightChange]);
+	}, [attachments.length, input, onHeightChange]);
 
-	// Focus the textarea on desktop for all chats, on mobile/tablet only for new chats.
 	useEffect(() => {
 		if (textareaRef.current && (isDesktop || !paramsChatId)) {
 			textareaRef.current.focus();
@@ -154,15 +185,24 @@ export default function UserPromptInput(props: Props) {
 					handlePromptSubmit();
 				}}
 			>
+				<PromptAttachmentsInput
+					attachments={attachments}
+					fileInputRef={fileInputRef}
+					onChange={handleAttachmentChange}
+					onRemove={removeAttachment}
+				/>
+
 				<div className="flex-1">
 					<textarea
 						className="max-h-80 min-h-8 w-full resize-none text-sm focus:outline-none"
 						disabled={
-							createChatMutation.isPending || createMessageMutation.isPending
+							isSubmittingPrompt ||
+							isUploading ||
+							createChatMutation.isPending ||
+							createMessageMutation.isPending
 						}
 						onChange={(e) => {
 							setInput(e.target.value);
-							// resizeTextarea();
 						}}
 						onKeyDown={(e) => {
 							if (e.key === "Enter" && !e.shiftKey) {
@@ -177,7 +217,18 @@ export default function UserPromptInput(props: Props) {
 					/>
 				</div>
 
-				<PromptActions status={props.status} stop={props.stop} />
+				<PromptActions
+					attachmentCount={attachments.length}
+					disabled={
+						isSubmittingPrompt ||
+						isUploading ||
+						createChatMutation.isPending ||
+						createMessageMutation.isPending
+					}
+					onAttachClick={() => fileInputRef.current?.click()}
+					status={props.status}
+					stop={props.stop}
+				/>
 			</form>
 		</div>
 	);

--- a/src/components/web-search-button.tsx
+++ b/src/components/web-search-button.tsx
@@ -1,0 +1,47 @@
+import { GlobeIcon } from "@phosphor-icons/react";
+import { useHotkey } from "@tanstack/react-hotkeys";
+import { cn } from "~/lib/utils";
+import { modelStoreActions, useModelStore } from "~/stores/model-store";
+import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
+import { Button } from "./ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+export default function WebSearchButton() {
+	useHotkey("Mod+Shift+S", modelStoreActions.toggleIsWebSearch);
+
+	const isWebSearchEnabled = useModelStore((store) => store.isWebSearchEnabled);
+	const selectedModel = useModelStore((store) => store.selectedModel);
+	const persistedUseOpenRouter = usePersistedApiKeysStore(
+		(store) => store.persistedUseOpenRouter,
+	);
+
+	if (
+		!selectedModel.openRouterModelId.startsWith("google") &&
+		!persistedUseOpenRouter
+	) {
+		return null;
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<Button
+						className={cn(
+							"transition-all duration-300 ease-out",
+							isWebSearchEnabled ? "border-primary" : "border-border",
+						)}
+						onClick={modelStoreActions.toggleIsWebSearch}
+						type="button"
+						variant={isWebSearchEnabled ? "default" : "outline"}
+					>
+						<GlobeIcon />
+						<span className="hidden sm:inline">Search</span>
+						<span className="sm:hidden">Web</span>
+					</Button>
+				}
+			/>
+			<TooltipContent>Ctrl+Shift+S</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -112,6 +112,11 @@ export function usePromptAttachments() {
 		const validFiles = Array.from(files).filter((file) => {
 			const mediaType = inferMediaType(file);
 
+			if (file.size === 0) {
+				toast.warning(`${file.name} is empty.`);
+				return false;
+			}
+
 			if (!isSupportedAttachmentType(mediaType)) {
 				toast.warning(`${file.name} is not a supported file, PDF, or image.`);
 				return false;

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -61,6 +61,7 @@ type UploadedAttachment = {
 	textContent?: string;
 };
 
+// Generate a local preview immediately because persisted file URLs are resolved later.
 const fileToDataUrl = (file: File) =>
 	new Promise<string>((resolve, reject) => {
 		const reader = new FileReader();
@@ -69,11 +70,13 @@ const fileToDataUrl = (file: File) =>
 		reader.readAsDataURL(file);
 	});
 
+// Fall back to extensions because browser MIME types are inconsistent for text files.
 const getFileExtension = (filename: string) => {
 	const parts = filename.toLowerCase().split(".");
 	return parts.length > 1 ? (parts.at(-1) ?? "") : "";
 };
 
+// Derive a stable media type so validation and downstream prompt handling stay consistent.
 const inferMediaType = (file: File) => {
 	if (file.type.trim() !== "") {
 		return file.type;
@@ -91,13 +94,14 @@ const inferMediaType = (file: File) => {
 	return "application/octet-stream";
 };
 
+// Limit attachments to types the UI and chat pipeline know how to handle safely.
 const isSupportedAttachmentType = (mediaType: string) =>
 	mediaType.startsWith("text/") ||
 	mediaType.startsWith("image/") ||
 	mediaType === "application/pdf";
 
+// Check extensions as well because some text formats are mislabeled as application/*.
 const isTextAttachment = (file: File, mediaType: string) => {
-	// Some text files are reported as application/* by the browser.
 	if (mediaType.startsWith("text/")) {
 		return true;
 	}
@@ -105,10 +109,12 @@ const isTextAttachment = (file: File, mediaType: string) => {
 	return TEXT_FILE_EXTENSIONS.has(getFileExtension(file.name));
 };
 
+// Keep prompt submission focused on messaging while this hook owns attachment state and uploads.
 export function usePromptAttachments() {
 	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
 
+	// Validate early so unsupported files never enter prompt state and text can be captured once.
 	const handleAttachmentChange = async (
 		event: ChangeEvent<HTMLInputElement>,
 	) => {
@@ -118,13 +124,14 @@ export function usePromptAttachments() {
 		}
 
 		const validFiles = Array.from(files).filter((file) => {
-			const mediaType = inferMediaType(file);
-
 			if (file.size === 0) {
 				toast.warning(`${file.name} is empty.`);
 				return false;
 			}
 
+			const mediaType = inferMediaType(file);
+
+			// Extension-based text files should be allowed even when the browser reports application/*.
 			if (
 				!isSupportedAttachmentType(mediaType) &&
 				!isTextAttachment(file, mediaType)
@@ -149,6 +156,7 @@ export function usePromptAttachments() {
 		const nextAttachments = await Promise.all(
 			validFiles.map(async (file) => {
 				const mediaType = inferMediaType(file);
+				// Capture text once up front so prompt construction does not depend on later file reads.
 				const textContent = isTextAttachment(file, mediaType)
 					? await file.text()
 					: undefined;
@@ -168,16 +176,19 @@ export function usePromptAttachments() {
 		event.target.value = "";
 	};
 
+	// Remove by index to preserve the user-visible ordering of the remaining attachments.
 	const removeAttachment = (index: number) => {
 		setAttachments((current) =>
 			current.filter((_, currentIndex) => currentIndex !== index),
 		);
 	};
 
+	// Reset attachments after send or cancel so the next prompt starts from a clean state.
 	const clearAttachments = () => {
 		setAttachments([]);
 	};
 
+	// Return preview-backed parts for the live UI and storage-backed parts for persisted messages.
 	const uploadAttachments = async (): Promise<{
 		optimisticAttachments: FileUIPart[];
 		persistedAttachments: FileUIPart[];
@@ -194,6 +205,7 @@ export function usePromptAttachments() {
 		try {
 			const uploadedAttachments: UploadedAttachment[] = await Promise.all(
 				attachments.map(async (attachment) => {
+					// Each file gets its own upload URL so storage authorization stays scoped to that upload.
 					const uploadUrl = await getPostUrl();
 					const uploadResponse = await fetch(uploadUrl, {
 						method: "POST",
@@ -216,7 +228,7 @@ export function usePromptAttachments() {
 						mediaType: attachment.mediaType,
 						previewUrl: attachment.previewUrl,
 						storageId,
-						// Persist an empty URL; Convex hydrates the authorized URL on read.
+						// Leave URLs empty here because authorized storage URLs are generated on read.
 						storageUrl: "",
 						textContent: attachment.textContent,
 					};
@@ -230,6 +242,7 @@ export function usePromptAttachments() {
 							type: "file",
 							filename: attachment.filename,
 							mediaType: attachment.mediaType,
+							// Keep the local preview in the optimistic message so the UI updates immediately.
 							url: attachment.previewUrl,
 							providerMetadata: {
 								baychat: {
@@ -247,6 +260,7 @@ export function usePromptAttachments() {
 							type: "file",
 							filename: attachment.filename,
 							mediaType: attachment.mediaType,
+							// Persist storage metadata instead of a transient preview URL.
 							url: attachment.storageUrl,
 							providerMetadata: {
 								baychat: {

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -1,0 +1,240 @@
+import type { FileUIPart } from "ai";
+import type { Id } from "convex/_generated/dataModel";
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { getFileUrl } from "~/server-fns/get-file-url";
+import { getPostUrl } from "~/server-fns/get-post-url";
+
+const TEXT_FILE_EXTENSIONS = new Set([
+	"c",
+	"cc",
+	"cpp",
+	"cxx",
+	"h",
+	"hh",
+	"hpp",
+	"go",
+	"js",
+	"jsx",
+	"ts",
+	"tsx",
+	"json",
+	"md",
+	"txt",
+	"py",
+	"java",
+	"rs",
+	"rb",
+	"php",
+	"css",
+	"scss",
+	"html",
+	"xml",
+	"yaml",
+	"yml",
+	"sh",
+	"sql",
+	"kt",
+	"swift",
+	"toml",
+	"ini",
+	"env",
+]);
+
+export type PendingAttachment = {
+	file: File;
+	filename: string;
+	mediaType: string;
+	previewUrl: string;
+	size: number;
+	textContent?: string;
+};
+
+type UploadedAttachment = {
+	filename: string;
+	mediaType: string;
+	previewUrl: string;
+	storageId: Id<"_storage">;
+	storageUrl: string;
+	textContent?: string;
+};
+
+const fileToDataUrl = (file: File) =>
+	new Promise<string>((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = () => reject(reader.error);
+		reader.readAsDataURL(file);
+	});
+
+const getFileExtension = (filename: string) => {
+	const parts = filename.toLowerCase().split(".");
+	return parts.length > 1 ? (parts.at(-1) ?? "") : "";
+};
+
+const inferMediaType = (file: File) => {
+	if (file.type.trim() !== "") {
+		return file.type;
+	}
+
+	const extension = getFileExtension(file.name);
+	if (TEXT_FILE_EXTENSIONS.has(extension)) {
+		return "text/plain";
+	}
+
+	if (extension === "pdf") {
+		return "application/pdf";
+	}
+
+	return "application/octet-stream";
+};
+
+export function usePromptAttachments() {
+	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+	const [isUploading, setIsUploading] = useState(false);
+
+	const handleAttachmentChange = async (
+		event: ChangeEvent<HTMLInputElement>,
+	) => {
+		const files = event.target.files;
+		if (!files || files.length === 0) {
+			return;
+		}
+
+		const nextAttachments = await Promise.all(
+			Array.from(files).map(async (file) => {
+				const mediaType = inferMediaType(file);
+				const textContent =
+					mediaType === "text/plain" ? await file.text() : undefined;
+
+				return {
+					file,
+					filename: file.name,
+					mediaType,
+					size: file.size,
+					previewUrl: await fileToDataUrl(file),
+					textContent,
+				};
+			}),
+		);
+
+		setAttachments((current) => [...current, ...nextAttachments]);
+		event.target.value = "";
+	};
+
+	const removeAttachment = (index: number) => {
+		setAttachments((current) =>
+			current.filter((_, currentIndex) => currentIndex !== index),
+		);
+	};
+
+	const clearAttachments = () => {
+		setAttachments([]);
+	};
+
+	const uploadAttachments = async (): Promise<{
+		optimisticAttachments: FileUIPart[];
+		persistedAttachments: FileUIPart[];
+	}> => {
+		if (attachments.length === 0) {
+			return {
+				optimisticAttachments: [],
+				persistedAttachments: [],
+			};
+		}
+
+		setIsUploading(true);
+
+		try {
+			const uploadedAttachments: UploadedAttachment[] = await Promise.all(
+				attachments.map(async (attachment) => {
+					const uploadUrl = await getPostUrl();
+					const uploadResponse = await fetch(uploadUrl, {
+						method: "POST",
+						headers: {
+							"Content-Type": attachment.mediaType,
+						},
+						body: attachment.file,
+					});
+
+					if (!uploadResponse.ok) {
+						throw new Error(`Upload failed: ${uploadResponse.status}`);
+					}
+
+					const { storageId } = (await uploadResponse.json()) as {
+						storageId: Id<"_storage">;
+					};
+					const storageUrl = await getFileUrl({
+						data: { storageId },
+					});
+
+					if (!storageUrl) {
+						throw new Error("File URL generation failed");
+					}
+
+					return {
+						filename: attachment.filename,
+						mediaType: attachment.mediaType,
+						previewUrl: attachment.previewUrl,
+						storageId,
+						storageUrl,
+						textContent: attachment.textContent,
+					};
+				}),
+			);
+
+			return {
+				optimisticAttachments: uploadedAttachments.map(
+					(attachment) =>
+						({
+							type: "file",
+							filename: attachment.filename,
+							mediaType: attachment.mediaType,
+							url: attachment.previewUrl,
+							providerMetadata: {
+								baychat: {
+									textContent: attachment.textContent,
+								},
+								convex: {
+									storageId: attachment.storageId,
+								},
+							},
+						}) satisfies FileUIPart,
+				),
+				persistedAttachments: uploadedAttachments.map(
+					(attachment) =>
+						({
+							type: "file",
+							filename: attachment.filename,
+							mediaType: attachment.mediaType,
+							url: attachment.storageUrl,
+							providerMetadata: {
+								baychat: {
+									textContent: attachment.textContent,
+								},
+								convex: {
+									storageId: attachment.storageId,
+								},
+							},
+						}) satisfies FileUIPart,
+				),
+			};
+		} catch (error) {
+			console.error("Failed to upload attachments:", error);
+			toast.error("Could not upload attachment");
+			throw error;
+		} finally {
+			setIsUploading(false);
+		}
+	};
+
+	return {
+		attachments,
+		clearAttachments,
+		handleAttachmentChange,
+		isUploading,
+		removeAttachment,
+		uploadAttachments,
+	};
+}

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -42,6 +42,8 @@ const TEXT_FILE_EXTENSIONS = new Set([
 	"env",
 ]);
 
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+
 export type PendingAttachment = {
 	file: File;
 	filename: string;
@@ -90,6 +92,11 @@ const inferMediaType = (file: File) => {
 	return "application/octet-stream";
 };
 
+const isSupportedAttachmentType = (mediaType: string) =>
+	mediaType.startsWith("text/") ||
+	mediaType.startsWith("image/") ||
+	mediaType === "application/pdf";
+
 export function usePromptAttachments() {
 	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
@@ -102,8 +109,29 @@ export function usePromptAttachments() {
 			return;
 		}
 
+		const validFiles = Array.from(files).filter((file) => {
+			const mediaType = inferMediaType(file);
+
+			if (!isSupportedAttachmentType(mediaType)) {
+				toast.warning(`${file.name} is not a supported file, PDF, or image.`);
+				return false;
+			}
+
+			if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+				toast.warning(`${file.name} is larger than 10 MB.`);
+				return false;
+			}
+
+			return true;
+		});
+
+		if (validFiles.length === 0) {
+			event.target.value = "";
+			return;
+		}
+
 		const nextAttachments = await Promise.all(
-			Array.from(files).map(async (file) => {
+			validFiles.map(async (file) => {
 				const mediaType = inferMediaType(file);
 				const textContent =
 					mediaType === "text/plain" ? await file.text() : undefined;

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -3,7 +3,6 @@ import type { Id } from "convex/_generated/dataModel";
 import type { ChangeEvent } from "react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { getFileUrl } from "~/server-fns/get-file-url";
 import { getPostUrl } from "~/server-fns/get-post-url";
 
 const TEXT_FILE_EXTENSIONS = new Set([
@@ -97,6 +96,15 @@ const isSupportedAttachmentType = (mediaType: string) =>
 	mediaType.startsWith("image/") ||
 	mediaType === "application/pdf";
 
+const isTextAttachment = (file: File, mediaType: string) => {
+	// Some text files are reported as application/* by the browser.
+	if (mediaType.startsWith("text/")) {
+		return true;
+	}
+
+	return TEXT_FILE_EXTENSIONS.has(getFileExtension(file.name));
+};
+
 export function usePromptAttachments() {
 	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
@@ -117,7 +125,10 @@ export function usePromptAttachments() {
 				return false;
 			}
 
-			if (!isSupportedAttachmentType(mediaType)) {
+			if (
+				!isSupportedAttachmentType(mediaType) &&
+				!isTextAttachment(file, mediaType)
+			) {
 				toast.warning(`${file.name} is not a supported file, PDF, or image.`);
 				return false;
 			}
@@ -138,8 +149,9 @@ export function usePromptAttachments() {
 		const nextAttachments = await Promise.all(
 			validFiles.map(async (file) => {
 				const mediaType = inferMediaType(file);
-				const textContent =
-					mediaType === "text/plain" ? await file.text() : undefined;
+				const textContent = isTextAttachment(file, mediaType)
+					? await file.text()
+					: undefined;
 
 				return {
 					file,
@@ -198,20 +210,14 @@ export function usePromptAttachments() {
 					const { storageId } = (await uploadResponse.json()) as {
 						storageId: Id<"_storage">;
 					};
-					const storageUrl = await getFileUrl({
-						data: { storageId },
-					});
-
-					if (!storageUrl) {
-						throw new Error("File URL generation failed");
-					}
 
 					return {
 						filename: attachment.filename,
 						mediaType: attachment.mediaType,
 						previewUrl: attachment.previewUrl,
 						storageId,
-						storageUrl,
+						// Persist an empty URL; Convex hydrates the authorized URL on read.
+						storageUrl: "",
 						textContent: attachment.textContent,
 					};
 				}),

--- a/src/lib/build-user-message-parts.ts
+++ b/src/lib/build-user-message-parts.ts
@@ -1,3 +1,4 @@
+import type { FileUIPart } from "ai";
 import { isImageGenerationModel } from "~/lib/is-image-generation-model";
 import type { CustomUIMessage, Model } from "~/types";
 
@@ -11,22 +12,26 @@ const isValidImageUrl = (value: string) => {
 };
 
 export const buildUserMessageParts = ({
+	attachments = [],
 	latestGeneratedImageUrl,
 	model,
 	prompt,
 }: {
+	attachments?: FileUIPart[];
 	latestGeneratedImageUrl?: string | null;
 	model: Model;
 	prompt: string;
 }): CustomUIMessage["parts"] => {
-	const textPart = { type: "text" as const, text: prompt };
+	const trimmedPrompt = prompt.trim();
+	const textPart =
+		trimmedPrompt.length > 0 ? [{ type: "text" as const, text: prompt }] : [];
 
 	if (!isImageGenerationModel(model)) {
-		return [textPart];
+		return [...attachments, ...textPart];
 	}
 
 	if (!latestGeneratedImageUrl || !isValidImageUrl(latestGeneratedImageUrl)) {
-		return [textPart];
+		return [...attachments, ...textPart];
 	}
 
 	return [
@@ -35,6 +40,7 @@ export const buildUserMessageParts = ({
 			mediaType: "image/png",
 			url: latestGeneratedImageUrl,
 		},
-		textPart,
+		...attachments,
+		...textPart,
 	];
 };

--- a/src/lib/get-file-parts-from-message.ts
+++ b/src/lib/get-file-parts-from-message.ts
@@ -1,0 +1,7 @@
+import type { FileUIPart } from "ai";
+import type { CustomUIMessage } from "~/types";
+
+export const getFilePartsFromMessage = (
+	parts: CustomUIMessage["parts"],
+): FileUIPart[] =>
+	parts.filter((part): part is FileUIPart => part.type === "file");

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -163,7 +163,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 					<TooltipProvider delay={0}>
 						<ChatProvider>
 							<div>{children}</div>
-							<Toaster duration={800} style={{ fontFamily: "inherit" }} />
+							<Toaster style={{ fontFamily: "inherit" }} />
 							{/*<ReactQueryDevtools />*/}
 							<Scripts />
 						</ChatProvider>

--- a/src/routes/api.chat.ts
+++ b/src/routes/api.chat.ts
@@ -190,6 +190,54 @@ const processMessageParts = async (
 	return { partsToSave };
 };
 
+const getTextAttachmentPromptPart = (part: FileUIPart) => {
+	const textContent = part.providerMetadata?.baychat?.textContent;
+	if (typeof textContent !== "string" || textContent.trim() === "") {
+		return null;
+	}
+
+	return {
+		type: "text" as const,
+		text: `Attached file: ${part.filename ?? "untitled"}\n\n${textContent}`,
+	};
+};
+
+const transformMessagesForModel = (
+	messages: CustomUIMessage[],
+): CustomUIMessage[] =>
+	messages.map((message) => {
+		if (message.role !== "user") {
+			return message;
+		}
+
+		const transformedParts: CustomUIMessage["parts"] = [];
+
+		for (const part of message.parts) {
+			if (part.type !== "file") {
+				transformedParts.push(part);
+				continue;
+			}
+
+			if (
+				part.mediaType.startsWith("image/") ||
+				part.mediaType === "application/pdf"
+			) {
+				transformedParts.push(part);
+				continue;
+			}
+
+			const textPart = getTextAttachmentPromptPart(part);
+			if (textPart) {
+				transformedParts.push(textPart);
+			}
+		}
+
+		return {
+			...message,
+			parts: transformedParts,
+		};
+	});
+
 type ChatRequestBody = {
 	messages: CustomUIMessage[];
 	model: Model;
@@ -228,7 +276,9 @@ export const Route = createFileRoute("/api/chat")({
 				const result = streamText({
 					model: modelToUse,
 					system: systemMessage,
-					messages: await convertToModelMessages(messages),
+					messages: await convertToModelMessages(
+						transformMessagesForModel(messages),
+					),
 					temperature: 0.7,
 					experimental_transform: smoothStream({ chunking: "line" }),
 					abortSignal: request.signal,

--- a/src/routes/api.chat.ts
+++ b/src/routes/api.chat.ts
@@ -10,7 +10,7 @@ import type { FileUIPart, UIMessagePart, UIDataTypes, UITools } from "ai";
 import { api } from "convex/_generated/api";
 import { defaultSelectedModel } from "~/constants/model-providers";
 import { systemMessage } from "~/constants/system-message";
-import { fetchAuthMutation, fetchAuthQuery } from "~/lib/auth-server";
+import { fetchAuthMutation } from "~/lib/auth-server";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { createMessageServerFn } from "~/server-fns/create-message";
 import { getAuthUser } from "~/server-fns/get-auth";
@@ -102,7 +102,10 @@ const uploadImage = async (part: FileUIPart) => {
 	if (!result.ok) throw new Error(`Upload failed: ${result.status}`);
 
 	const { storageId } = await result.json();
-	const imageUrl = await fetchAuthQuery(api.files.getImageUrl, { storageId });
+	// This stores ownership and returns the URL in one authenticated mutation.
+	const imageUrl = await fetchAuthMutation(api.imageGenerations.create, {
+		storageId,
+	});
 
 	return { storageId, imageUrl };
 };
@@ -162,16 +165,8 @@ const processMessageParts = async (
 					if (!uploadedImage) {
 						return null;
 					}
-					const { imageUrl, storageId } = uploadedImage;
+					const { imageUrl } = uploadedImage;
 					if (imageUrl) {
-						try {
-							await fetchAuthMutation(api.imageGenerations.create, {
-								generatedImageUrl: imageUrl,
-								storageId,
-							});
-						} catch (galleryError) {
-							console.error("Failed to save to gallery:", galleryError);
-						}
 						return { ...part, url: imageUrl };
 					}
 				} catch (error) {
@@ -218,10 +213,10 @@ const transformMessagesForModel = (
 				continue;
 			}
 
-			if (
-				part.mediaType.startsWith("image/") ||
-				part.mediaType === "application/pdf"
-			) {
+			const mediaType =
+				typeof part.mediaType === "string" ? part.mediaType : "";
+			// Treat malformed file parts as non-media instead of crashing.
+			if (mediaType.startsWith("image/") || mediaType === "application/pdf") {
 				transformedParts.push(part);
 				continue;
 			}

--- a/src/server-fns/get-file-url.ts
+++ b/src/server-fns/get-file-url.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import { api } from "convex/_generated/api";
+import { Id } from "convex/_generated/dataModel";
 import { z } from "zod";
 import { fetchAuthQuery } from "~/lib/auth-server";
 import { getAuthUser } from "./get-auth";
@@ -17,6 +18,6 @@ export const getFileUrl = createServerFn({ method: "GET" })
 		}
 
 		return fetchAuthQuery(api.files.getFileUrl, {
-			storageId: data.storageId as any,
+			storageId: data.storageId as Id<"_storage">,
 		});
 	});

--- a/src/server-fns/get-file-url.ts
+++ b/src/server-fns/get-file-url.ts
@@ -1,0 +1,22 @@
+import { createServerFn } from "@tanstack/react-start";
+import { api } from "convex/_generated/api";
+import { z } from "zod";
+import { fetchAuthQuery } from "~/lib/auth-server";
+import { getAuthUser } from "./get-auth";
+
+export const getFileUrl = createServerFn({ method: "GET" })
+	.inputValidator(
+		z.object({
+			storageId: z.string(),
+		}),
+	)
+	.handler(async ({ data }) => {
+		const authData = await getAuthUser();
+		if (!authData) {
+			throw new Error("Invalid request");
+		}
+
+		return fetchAuthQuery(api.files.getFileUrl, {
+			storageId: data.storageId as any,
+		});
+	});


### PR DESCRIPTION
Fixes #8 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file attachments to chat with previews, upload state, and secure per-user URL handling. Users can attach images, PDFs, or text/code files; uploads are stored, authorized, hydrated, and shown in messages.

- **New Features**
  - Attach files (images, PDFs, text/code) up to 10 MB; empty/unsupported files are rejected.
  - Preview attachments with thumbnails/icons and sizes; remove before sending.
  - Uploads show optimistic previews and a progress state; upload button shows an attachment count; inputs are disabled while uploading.
  - Messages render attachments above text; edits preserve attachments; prompts with only files are allowed.

- **Refactors**
  - Unified secure file URL access via `getFileUrl`/`getImageUrl`; ownership enforced for gallery images and prompt uploads using a new `uploadedFiles` table.
  - Message queries hydrate fresh, authorized URLs for stored file parts on read.
  - Text/code attachments are inferred by extension when needed and converted to text for the model; images/PDFs are sent as file parts.
  - New utilities/components: `use-prompt-attachments`, `PromptAttachmentsInput`, `FileAttachmentsPreview`, `InputUploadButton`, `WebSearchButton`, `get-file-parts-from-message`.
  - Image URL derivation moved into `imageGenerations.create`, which now returns the generated URL and records ownership.

<sup>Written for commit 82852208a338b22e57af0882600f2202c0b35bdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

