### PR TITLE
Paste images in input

### DIFF
--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import type { ChatStatus } from "ai";
 import { api } from "convex/_generated/api";
 import type { Id } from "convex/_generated/dataModel";
+import type { ClipboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useIsDesktop } from "~/hooks/use-desktop";
 import { usePromptAttachments } from "~/hooks/use-prompt-attachments";
@@ -49,6 +50,7 @@ export default function UserPromptInput(props: Props) {
 	const {
 		attachments,
 		clearAttachments,
+		handleClipboardFiles,
 		handleAttachmentChange,
 		isUploading,
 		removeAttachment,
@@ -159,6 +161,20 @@ export default function UserPromptInput(props: Props) {
 		}
 	};
 
+	const handlePaste = async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+		const clipboardFiles = Array.from(event.clipboardData.items)
+			.filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+			.map((item) => item.getAsFile())
+			.filter((file): file is File => file !== null);
+
+		if (clipboardFiles.length === 0) {
+			return;
+		}
+
+		event.preventDefault();
+		await handleClipboardFiles(clipboardFiles);
+	};
+
 	useEffect(() => {
 		resizeTextarea();
 	}, [input]);
@@ -209,6 +225,9 @@ export default function UserPromptInput(props: Props) {
 								e.preventDefault();
 								handlePromptSubmit();
 							}
+						}}
+						onPaste={(e) => {
+							handlePaste(e);
 						}}
 						placeholder="Start the conversation..."
 						ref={textareaRef}

--- a/src/hooks/use-prompt-attachments.ts
+++ b/src/hooks/use-prompt-attachments.ts
@@ -43,6 +43,15 @@ const TEXT_FILE_EXTENSIONS = new Set([
 
 const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
 
+const MIME_TYPE_TO_EXTENSION: Record<string, string> = {
+	"image/gif": "gif",
+	"image/heic": "heic",
+	"image/heif": "heif",
+	"image/jpeg": "jpg",
+	"image/png": "png",
+	"image/webp": "webp",
+};
+
 export type PendingAttachment = {
 	file: File;
 	filename: string;
@@ -94,6 +103,15 @@ const inferMediaType = (file: File) => {
 	return "application/octet-stream";
 };
 
+const getClipboardImageFilename = (file: File) => {
+	if (file.name.trim() !== "") {
+		return file.name;
+	}
+
+	const extension = MIME_TYPE_TO_EXTENSION[file.type] ?? "png";
+	return `clipboard-image-${Date.now()}.${extension}`;
+};
+
 // Limit attachments to types the UI and chat pipeline know how to handle safely.
 const isSupportedAttachmentType = (mediaType: string) =>
 	mediaType.startsWith("text/") ||
@@ -114,16 +132,8 @@ export function usePromptAttachments() {
 	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
 
-	// Validate early so unsupported files never enter prompt state and text can be captured once.
-	const handleAttachmentChange = async (
-		event: ChangeEvent<HTMLInputElement>,
-	) => {
-		const files = event.target.files;
-		if (!files || files.length === 0) {
-			return;
-		}
-
-		const validFiles = Array.from(files).filter((file) => {
+	const queueFiles = async (files: File[]) => {
+		const validFiles = files.filter((file) => {
 			if (file.size === 0) {
 				toast.warning(`${file.name} is empty.`);
 				return false;
@@ -149,7 +159,6 @@ export function usePromptAttachments() {
 		});
 
 		if (validFiles.length === 0) {
-			event.target.value = "";
 			return;
 		}
 
@@ -173,7 +182,29 @@ export function usePromptAttachments() {
 		);
 
 		setAttachments((current) => [...current, ...nextAttachments]);
+	};
+
+	// Validate early so unsupported files never enter prompt state and text can be captured once.
+	const handleAttachmentChange = async (
+		event: ChangeEvent<HTMLInputElement>,
+	) => {
+		const files = event.target.files;
+		if (!files || files.length === 0) {
+			return;
+		}
+
+		await queueFiles(Array.from(files));
 		event.target.value = "";
+	};
+
+	const handleClipboardFiles = async (files: File[]) => {
+		const clipboardFiles = files.map((file) =>
+			file.name.trim() === ""
+				? new File([file], getClipboardImageFilename(file), { type: file.type })
+				: file,
+		);
+
+		await queueFiles(clipboardFiles);
 	};
 
 	// Remove by index to preserve the user-visible ordering of the remaining attachments.
@@ -285,6 +316,7 @@ export function usePromptAttachments() {
 	return {
 		attachments,
 		clearAttachments,
+		handleClipboardFiles,
 		handleAttachmentChange,
 		isUploading,
 		removeAttachment,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow users to paste images directly into the message input to add them as attachments. Clipboard images are auto-named and validated like normal uploads.

- New Features
  - Paste images into the input to attach them; multiple images supported.
  - Auto-generate filenames for clipboard images (e.g., clipboard-image-<timestamp> with correct extension).
  - Supports GIF, HEIC/HEIF, JPEG, PNG, and WebP; falls back to PNG when unknown.

- Refactors
  - Extracted shared file queuing/validation to `queueFiles` and reused in both file picker and paste flows.
  - Added `handleClipboardFiles` in `usePromptAttachments` to normalize clipboard images before enqueueing.

<sup>Written for commit f8d4fd74e95dfd1ff6b8bfc715ada538018e11e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

