### PR TITLE
View attachment content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,5 @@
 - use bun for all script runs
 - never run build
+- use the Shadcn components without any major updates
+- do not run fmt or lint script after every single change
+- one tsx file should have only one component logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 - use bun for all script runs
 - never run build
-- use the Shadcn components without any major updates
+- use the Shadcn components without modifying them too much
 - do not run fmt or lint script after every single change
 - one tsx file should have only one component logic

--- a/src/components/code-highlight.tsx
+++ b/src/components/code-highlight.tsx
@@ -93,7 +93,7 @@ export default function CodeHighlight({
 					delay={150}
 					language={language}
 					showLanguage={false}
-					theme={theme === "light" ? "github-light" : "vesper"}
+					theme={theme === "light" ? "vitesse-light" : "vesper"}
 				>
 					{codeContent}
 				</ShikiHighlighter>

--- a/src/components/file-attachments-preview.tsx
+++ b/src/components/file-attachments-preview.tsx
@@ -1,14 +1,8 @@
-import {
-	FileIcon,
-	FilePdfIcon,
-	FileTextIcon,
-	XIcon,
-} from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
 import { cn } from "~/lib/utils";
 import ImageAttachmentPreview from "./image-attachment-preview";
+import PdfAttachmentPreview from "./pdf-attachment-preview";
 import TextFileAttachmentPreview from "./text-file-attachment-preview";
-import { Button } from "./ui/button";
 
 type AttachmentPart = FileUIPart & { size?: number };
 
@@ -42,18 +36,6 @@ const formatFileSize = (size?: number) => {
 
 const getAttachmentLabel = (attachment: AttachmentPart) =>
 	attachment.filename?.trim() || "Untitled file";
-
-const getAttachmentTypeLabel = (attachment: AttachmentPart) => {
-	if (attachment.mediaType === "application/pdf") {
-		return "PDF";
-	}
-
-	if (attachment.mediaType.startsWith("text/")) {
-		return "TEXT";
-	}
-
-	return "FILE";
-};
 
 export default function FileAttachmentsPreview({
 	attachments,
@@ -97,39 +79,14 @@ export default function FileAttachmentsPreview({
 				}
 
 				return (
-					<div
-						className="relative flex min-h-20 items-center gap-3 rounded-2xl border border-border/70 bg-linear-to-br from-muted/55 to-muted/15 px-3 py-3 shadow-sm"
+					<PdfAttachmentPreview
+						attachment={attachment}
+						fileSize={fileSize}
+						index={index}
 						key={`${attachment.url}-${index}`}
-					>
-						<div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80">
-							{attachment.mediaType.startsWith("text/") ? (
-								<FileTextIcon className="text-muted-foreground" />
-							) : attachment.mediaType === "application/pdf" ? (
-								<FilePdfIcon className="text-muted-foreground" />
-							) : (
-								<FileIcon className="text-muted-foreground" />
-							)}
-						</div>
-						<div className="min-w-0 flex-1">
-							<div className="truncate text-xs font-medium">{label}</div>
-							<div className="mt-1 flex items-center gap-2 text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
-								<span>{getAttachmentTypeLabel(attachment)}</span>
-								{fileSize && <span>{fileSize}</span>}
-							</div>
-						</div>
-						{onRemove && (
-							<Button
-								aria-label={`Remove ${label}`}
-								className="absolute top-2 right-2 rounded-full"
-								onClick={() => onRemove(index)}
-								size="icon-xs"
-								type="button"
-								variant="ghost"
-							>
-								<XIcon />
-							</Button>
-						)}
-					</div>
+						label={label}
+						onRemove={onRemove}
+					/>
 				);
 			})}
 		</div>

--- a/src/components/file-attachments-preview.tsx
+++ b/src/components/file-attachments-preview.tsx
@@ -6,6 +6,7 @@ import {
 } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
 import { cn } from "~/lib/utils";
+import ImageAttachmentPreview from "./image-attachment-preview";
 import { Button } from "./ui/button";
 
 type AttachmentPart = FileUIPart & { size?: number };
@@ -67,34 +68,14 @@ export default function FileAttachmentsPreview({
 
 				if (isImageAttachment(attachment)) {
 					return (
-						<div
-							className="group/attachment relative overflow-hidden rounded-2xl border border-border/70 bg-muted/40 shadow-sm"
+						<ImageAttachmentPreview
+							attachment={attachment}
+							fileSize={fileSize}
+							index={index}
 							key={`${attachment.url}-${index}`}
-						>
-							<img
-								alt={label}
-								className="h-28 w-full object-cover"
-								src={attachment.url}
-							/>
-							<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/80 to-transparent px-3 pt-8 pb-3">
-								<div className="truncate text-[11px] font-medium">{label}</div>
-								<div className="mt-0.5 text-[10px] text-muted-foreground">
-									{fileSize ?? "Image"}
-								</div>
-							</div>
-							{onRemove && (
-								<Button
-									aria-label={`Remove ${label}`}
-									className="absolute top-2 right-2 rounded-full bg-background/85 shadow-sm backdrop-blur"
-									onClick={() => onRemove(index)}
-									size="icon-xs"
-									type="button"
-									variant="outline"
-								>
-									<XIcon />
-								</Button>
-							)}
-						</div>
+							label={label}
+							onRemove={onRemove}
+						/>
 					);
 				}
 

--- a/src/components/file-attachments-preview.tsx
+++ b/src/components/file-attachments-preview.tsx
@@ -7,6 +7,7 @@ import {
 import type { FileUIPart } from "ai";
 import { cn } from "~/lib/utils";
 import ImageAttachmentPreview from "./image-attachment-preview";
+import TextFileAttachmentPreview from "./text-file-attachment-preview";
 import { Button } from "./ui/button";
 
 type AttachmentPart = FileUIPart & { size?: number };
@@ -19,6 +20,9 @@ type Props = {
 
 const isImageAttachment = (attachment: AttachmentPart) =>
 	attachment.mediaType.startsWith("image/");
+
+const isPdfAttachment = (attachment: AttachmentPart) =>
+	attachment.mediaType === "application/pdf";
 
 const formatFileSize = (size?: number) => {
 	if (size == null || Number.isNaN(size)) {
@@ -69,6 +73,19 @@ export default function FileAttachmentsPreview({
 				if (isImageAttachment(attachment)) {
 					return (
 						<ImageAttachmentPreview
+							attachment={attachment}
+							fileSize={fileSize}
+							index={index}
+							key={`${attachment.url}-${index}`}
+							label={label}
+							onRemove={onRemove}
+						/>
+					);
+				}
+
+				if (!isPdfAttachment(attachment)) {
+					return (
+						<TextFileAttachmentPreview
 							attachment={attachment}
 							fileSize={fileSize}
 							index={index}

--- a/src/components/image-attachment-preview.tsx
+++ b/src/components/image-attachment-preview.tsx
@@ -1,0 +1,115 @@
+import { XIcon } from "@phosphor-icons/react";
+import { FileUIPart } from "ai";
+import { useState } from "react";
+import { Button } from "./ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./ui/dialog";
+
+type AttachmentPart = FileUIPart & { size?: number };
+
+const getImageTypeLabel = (mediaType: string) =>
+	mediaType.split("/")[1]?.replace(/[-_]/g, " ").toUpperCase() || "IMAGE";
+
+export default function ImageAttachmentPreview({
+	attachment,
+	index,
+	label,
+	fileSize,
+	onRemove,
+}: {
+	attachment: AttachmentPart;
+	index: number;
+	label: string;
+	fileSize: string | null;
+	onRemove?: (index: number) => void;
+}) {
+	const [dimensions, setDimensions] = useState<{
+		height: number;
+		width: number;
+	} | null>(null);
+
+	return (
+		<Dialog>
+			<div className="group/attachment relative overflow-hidden rounded-2xl border border-border/70 bg-muted/40 shadow-sm">
+				<DialogTrigger
+					render={
+						<button
+							type="button"
+							className="block w-full cursor-zoom-in rounded-[inherit] text-left outline-none focus:outline-none"
+						>
+							<img
+								alt={label}
+								className="h-28 w-full object-cover"
+								onLoad={(event) => {
+									if (dimensions) {
+										return;
+									}
+
+									setDimensions({
+										height: event.currentTarget.naturalHeight,
+										width: event.currentTarget.naturalWidth,
+									});
+								}}
+								src={attachment.url}
+							/>
+							<div className="absolute inset-x-0 bottom-0 space-y-0.5 bg-linear-to-t from-background via-background/80 to-transparent px-3 pt-8 pb-3">
+								<div className="truncate text-xs font-medium">{label}</div>
+								<div className="text-xs text-muted-foreground">
+									{fileSize ?? "Image"}
+								</div>
+							</div>
+						</button>
+					}
+				/>
+				{onRemove && (
+					<Button
+						aria-label={`Remove ${label}`}
+						className="absolute top-2 right-2 rounded-full bg-background/85 shadow-sm backdrop-blur"
+						onClick={(event) => {
+							event.stopPropagation();
+							onRemove(index);
+						}}
+						size="icon-xs"
+						type="button"
+						variant="outline"
+					>
+						<XIcon />
+					</Button>
+				)}
+			</div>
+
+			<DialogContent className="max-h-[90vh] overflow-hidden sm:max-w-4xl">
+				<DialogHeader className="pr-10">
+					<DialogTitle className="truncate text-sm">{label}</DialogTitle>
+					<div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+						<div>{getImageTypeLabel(attachment.mediaType)}</div>
+						{fileSize && <div>{fileSize}</div>}
+					</div>
+				</DialogHeader>
+
+				<div className="flex max-h-[calc(90vh-6rem)] items-center justify-center overflow-auto rounded-md bg-muted/30 p-2">
+					<img
+						alt={label}
+						className="block max-h-full max-w-full object-contain"
+						onLoad={(event) => {
+							if (dimensions) {
+								return;
+							}
+
+							setDimensions({
+								height: event.currentTarget.naturalHeight,
+								width: event.currentTarget.naturalWidth,
+							});
+						}}
+						src={attachment.url}
+					/>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -1,0 +1,121 @@
+import { ArrowSquareOutIcon, FilePdfIcon, XIcon } from "@phosphor-icons/react";
+import type { FileUIPart } from "ai";
+import { Button } from "./ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./ui/dialog";
+
+type AttachmentPart = FileUIPart & { size?: number };
+
+export default function PdfAttachmentPreview({
+	attachment,
+	fileSize,
+	index,
+	label,
+	onRemove,
+}: {
+	attachment: AttachmentPart;
+	fileSize: string | null;
+	index: number;
+	label: string;
+	onRemove?: (index: number) => void;
+}) {
+	return (
+		<Dialog>
+			<div className="relative flex min-h-20 items-center gap-3 rounded-2xl border border-border/70 bg-linear-to-br from-muted/55 to-muted/15 px-3 py-3 shadow-sm">
+				<DialogTrigger
+					render={
+						<button
+							type="button"
+							className="flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-[inherit] text-left outline-none focus:outline-none"
+						>
+							<div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80">
+								<FilePdfIcon className="text-muted-foreground" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="truncate text-xs font-medium">{label}</div>
+								<div className="mt-1 flex items-center gap-2 text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
+									<span>PDF</span>
+									{fileSize && <span>{fileSize}</span>}
+								</div>
+							</div>
+						</button>
+					}
+				/>
+
+				{onRemove && (
+					<Button
+						aria-label={`Remove ${label}`}
+						className="absolute top-2 right-2 rounded-full"
+						onClick={(event) => {
+							event.stopPropagation();
+							onRemove(index);
+						}}
+						size="icon-xs"
+						type="button"
+						variant="ghost"
+					>
+						<XIcon />
+					</Button>
+				)}
+			</div>
+
+			<DialogContent
+				className="flex h-[82vh] max-h-[82vh] flex-col gap-0 overflow-hidden rounded-[2rem] p-0 sm:max-w-[min(92vw,1600px)]"
+				showCloseButton={false}
+			>
+				<DialogHeader className="flex-row items-start justify-between px-7 pt-7 pb-4">
+					<div className="min-w-0">
+						<DialogTitle className="truncate pr-4 text-[1.05rem] font-medium">
+							{label}
+						</DialogTitle>
+						<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+							<span>PDF document</span>
+							{fileSize && <span>{fileSize}</span>}
+						</div>
+					</div>
+
+					<div className="flex shrink-0 items-center gap-2">
+						<Button
+							aria-label={`Open ${label} in a new tab`}
+							onClick={() => {
+								window.open(attachment.url, "_blank", "noopener,noreferrer");
+							}}
+							size="icon-sm"
+							type="button"
+							variant="outline"
+						>
+							<ArrowSquareOutIcon />
+						</Button>
+
+						<DialogClose
+							render={
+								<Button
+									aria-label={`Close ${label}`}
+									size="icon-sm"
+									type="button"
+									variant="outline"
+								/>
+							}
+						>
+							<XIcon />
+						</DialogClose>
+					</div>
+				</DialogHeader>
+
+				<div className="min-h-0 flex-1 px-5 pb-5">
+					<iframe
+						className="h-full min-h-0 w-full rounded-2xl border border-border/70 bg-background shadow-xs"
+						src={attachment.url}
+						title={label}
+					/>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -14,7 +14,7 @@ import {
 
 type AttachmentPart = FileUIPart & { size?: number };
 
-const isDirectBrowserUrl = (value: string) => {
+const isSafeBrowserUrl = (value: string) => {
 	try {
 		const url = new URL(value);
 		return (
@@ -40,6 +40,10 @@ export default function PdfAttachmentPreview({
 	label: string;
 	onRemove?: (index: number) => void;
 }) {
+	const inlinePdfUrl = isSafeBrowserUrl(attachment.url)
+		? attachment.url
+		: "about:blank";
+
 	const handleOpenInNewTab = async () => {
 		const newTab = window.open("", "_blank");
 
@@ -56,11 +60,15 @@ export default function PdfAttachmentPreview({
 				const response = await fetch(pdfUrl);
 				const pdfBlob = await response.blob();
 				pdfUrl = URL.createObjectURL(pdfBlob);
-			} else if (!isDirectBrowserUrl(pdfUrl) && typeof storageId === "string") {
+			} else if (!isSafeBrowserUrl(pdfUrl) && typeof storageId === "string") {
 				const freshUrl = await getFileUrl({ data: { storageId } });
 				if (typeof freshUrl === "string" && freshUrl.trim() !== "") {
 					pdfUrl = freshUrl;
 				}
+			}
+
+			if (!isSafeBrowserUrl(pdfUrl)) {
+				throw new Error("Invalid PDF URL");
 			}
 
 			newTab.location.replace(pdfUrl);
@@ -151,7 +159,7 @@ export default function PdfAttachmentPreview({
 				<div className="min-h-0 flex-1 px-5 pb-5">
 					<iframe
 						className="h-full min-h-0 w-full rounded-2xl border border-border/70 bg-background shadow-xs"
-						src={attachment.url}
+						src={inlinePdfUrl}
 						title={label}
 					/>
 				</div>

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -14,6 +14,19 @@ import {
 
 type AttachmentPart = FileUIPart & { size?: number };
 
+const isDirectBrowserUrl = (value: string) => {
+	try {
+		const url = new URL(value);
+		return (
+			url.protocol === "http:" ||
+			url.protocol === "https:" ||
+			url.protocol === "blob:"
+		);
+	} catch {
+		return false;
+	}
+};
+
 export default function PdfAttachmentPreview({
 	attachment,
 	fileSize,
@@ -39,17 +52,15 @@ export default function PdfAttachmentPreview({
 			const storageId = attachment.providerMetadata?.convex?.storageId;
 			let pdfUrl = attachment.url;
 
-			if (typeof storageId === "string") {
-				const freshUrl = await getFileUrl({ data: { storageId } });
-				if (typeof freshUrl === "string" && freshUrl.trim() !== "") {
-					pdfUrl = freshUrl;
-				}
-			}
-
 			if (pdfUrl.startsWith("data:")) {
 				const response = await fetch(pdfUrl);
 				const pdfBlob = await response.blob();
 				pdfUrl = URL.createObjectURL(pdfBlob);
+			} else if (!isDirectBrowserUrl(pdfUrl) && typeof storageId === "string") {
+				const freshUrl = await getFileUrl({ data: { storageId } });
+				if (typeof freshUrl === "string" && freshUrl.trim() !== "") {
+					pdfUrl = freshUrl;
+				}
 			}
 
 			newTab.location.replace(pdfUrl);

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -1,5 +1,7 @@
 import { ArrowSquareOutIcon, FilePdfIcon, XIcon } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
+import { toast } from "sonner";
+import { getFileUrl } from "~/server-fns/get-file-url";
 import { Button } from "./ui/button";
 import {
 	Dialog,
@@ -25,6 +27,39 @@ export default function PdfAttachmentPreview({
 	label: string;
 	onRemove?: (index: number) => void;
 }) {
+	const handleOpenInNewTab = async () => {
+		const newTab = window.open("", "_blank");
+
+		if (!newTab) {
+			toast.error("Could not open PDF in a new tab");
+			return;
+		}
+
+		try {
+			const storageId = attachment.providerMetadata?.convex?.storageId;
+			let pdfUrl = attachment.url;
+
+			if (typeof storageId === "string") {
+				const freshUrl = await getFileUrl({ data: { storageId } });
+				if (typeof freshUrl === "string" && freshUrl.trim() !== "") {
+					pdfUrl = freshUrl;
+				}
+			}
+
+			if (pdfUrl.startsWith("data:")) {
+				const response = await fetch(pdfUrl);
+				const pdfBlob = await response.blob();
+				pdfUrl = URL.createObjectURL(pdfBlob);
+			}
+
+			newTab.location.replace(pdfUrl);
+		} catch (error) {
+			newTab.close();
+			console.error("Failed to open PDF in a new tab:", error);
+			toast.error("Could not open PDF in a new tab");
+		}
+	};
+
 	return (
 		<Dialog>
 			<div className="relative flex min-h-20 items-center gap-3 rounded-2xl border border-border/70 bg-linear-to-br from-muted/55 to-muted/15 px-3 py-3 shadow-sm">
@@ -74,18 +109,12 @@ export default function PdfAttachmentPreview({
 						<DialogTitle className="truncate pr-4 text-[1.05rem] font-medium">
 							{label}
 						</DialogTitle>
-						<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-							<span>PDF document</span>
-							{fileSize && <span>{fileSize}</span>}
-						</div>
 					</div>
 
 					<div className="flex shrink-0 items-center gap-2">
 						<Button
 							aria-label={`Open ${label} in a new tab`}
-							onClick={() => {
-								window.open(attachment.url, "_blank", "noopener,noreferrer");
-							}}
+							onClick={handleOpenInNewTab}
 							size="icon-sm"
 							type="button"
 							variant="outline"

--- a/src/components/prompt-attachments-input.tsx
+++ b/src/components/prompt-attachments-input.tsx
@@ -26,6 +26,11 @@ export default function PromptAttachmentsInput({
 			mediaType: attachment.mediaType,
 			size: attachment.size,
 			url: attachment.previewUrl,
+			providerMetadata: {
+				baychat: {
+					textContent: attachment.textContent,
+				},
+			},
 		}));
 
 	return (

--- a/src/components/text-file-attachment-preview.tsx
+++ b/src/components/text-file-attachment-preview.tsx
@@ -1,0 +1,164 @@
+import { FileTextIcon, XIcon } from "@phosphor-icons/react";
+import type { FileUIPart } from "ai";
+import CodeHighlight from "./code-highlight";
+import { Button } from "./ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./ui/dialog";
+
+type AttachmentPart = FileUIPart & { size?: number };
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+	c: "c",
+	cc: "cpp",
+	cpp: "cpp",
+	css: "css",
+	env: "bash",
+	go: "go",
+	h: "c",
+	hpp: "cpp",
+	html: "html",
+	ini: "ini",
+	java: "java",
+	js: "js",
+	json: "json",
+	jsx: "jsx",
+	kt: "kotlin",
+	md: "markdown",
+	php: "php",
+	py: "python",
+	rb: "ruby",
+	rs: "rust",
+	scss: "scss",
+	sh: "bash",
+	sql: "sql",
+	swift: "swift",
+	toml: "toml",
+	ts: "ts",
+	tsx: "tsx",
+	txt: "txt",
+	xml: "xml",
+	yaml: "yaml",
+	yml: "yaml",
+};
+
+const getCodeLanguage = (attachment: AttachmentPart) => {
+	const extension = attachment.filename?.toLowerCase().split(".").at(-1) ?? "";
+	if (extension in LANGUAGE_BY_EXTENSION) {
+		return LANGUAGE_BY_EXTENSION[extension];
+	}
+
+	if (attachment.mediaType.includes("json")) {
+		return "json";
+	}
+
+	if (attachment.mediaType.includes("javascript")) {
+		return "js";
+	}
+
+	if (attachment.mediaType.includes("typescript")) {
+		return "ts";
+	}
+
+	if (attachment.mediaType.includes("html")) {
+		return "html";
+	}
+
+	if (attachment.mediaType.includes("css")) {
+		return "css";
+	}
+
+	if (attachment.mediaType.startsWith("text/")) {
+		return "txt";
+	}
+
+	return "txt";
+};
+
+const getTextContent = (attachment: AttachmentPart) => {
+	const textContent = attachment.providerMetadata?.baychat?.textContent;
+	return typeof textContent === "string" ? textContent : "";
+};
+
+export default function TextFileAttachmentPreview({
+	attachment,
+	fileSize,
+	index,
+	label,
+	onRemove,
+}: {
+	attachment: AttachmentPart;
+	fileSize: string | null;
+	index: number;
+	label: string;
+	onRemove?: (index: number) => void;
+}) {
+	const textContent = getTextContent(attachment);
+	const language = getCodeLanguage(attachment);
+
+	return (
+		<Dialog>
+			<div className="relative flex min-h-20 items-center gap-3 rounded-2xl border border-border/70 bg-linear-to-br from-muted/55 to-muted/15 px-3 py-3 shadow-sm">
+				<DialogTrigger
+					render={
+						<button
+							type="button"
+							className="flex w-full min-w-0 items-center gap-3 rounded-[inherit] text-left outline-none focus:outline-none"
+						>
+							<div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80">
+								<FileTextIcon className="text-muted-foreground" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="truncate text-xs font-medium">{label}</div>
+								<div className="mt-1 text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
+									{fileSize ?? "File"}
+								</div>
+							</div>
+						</button>
+					}
+				/>
+
+				{onRemove && (
+					<Button
+						aria-label={`Remove ${label}`}
+						className="absolute top-2 right-2 rounded-full"
+						onClick={(event) => {
+							event.stopPropagation();
+							onRemove(index);
+						}}
+						size="icon-xs"
+						type="button"
+						variant="ghost"
+					>
+						<XIcon />
+					</Button>
+				)}
+			</div>
+
+			<DialogContent className="max-h-[90vh] overflow-hidden sm:max-w-5xl">
+				<DialogHeader className="pr-10">
+					<DialogTitle className="truncate text-sm">{label}</DialogTitle>
+					<div className="text-xs text-muted-foreground">
+						{fileSize ?? "File"}
+					</div>
+				</DialogHeader>
+
+				<div className="max-h-[calc(90vh-6rem)] overflow-auto">
+					{textContent.trim() ? (
+						<CodeHighlight className={`language-${language}`}>
+							{textContent}
+						</CodeHighlight>
+					) : (
+						<div className="rounded-md border border-border/70 bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+							Preview unavailable.
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"baseUrl": ".",
 		"paths": {
-			"~/*": ["./src/*"]
+			"~/*": ["./src/*"],
+			"*": ["./*"]
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add in-app previews for images, PDFs, and text files in the attachment list. Dialogs include safe PDF URL handling, “Open in new tab” for PDFs, and improved code highlighting.

- **New Features**
  - Image preview dialog with larger view and file info.
  - PDF preview dialog with iframe and “Open in new tab”; validates URLs (http/https/blob), falls back to about:blank if unsafe, resolves `convex.storageId`, supports `data:` and `blob:` URLs, and shows errors.
  - Text file preview with syntax highlighting and language detection; falls back to plain text. Reads from `providerMetadata.baychat.textContent`.

- **Refactors**
  - Split previews into `image-attachment-preview.tsx`, `pdf-attachment-preview.tsx`, and `text-file-attachment-preview.tsx`; simplified `file-attachments-preview.tsx`; UX fixes for remove buttons and labels; updated `AGENTS.md` guidelines.
  - Switched Shiki light theme to `vitesse-light` in `CodeHighlight`.
  - TypeScript 6 path mapping: removed `baseUrl` and added `"*": ["./*"]` in `tsconfig.json`.

<sup>Written for commit 0f0e8e9db61bfab521bd3ff3865289eb104029d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

