### PR TITLE
add date-range division

### DIFF
--- a/src/components/app-sidebar-chat-item.tsx
+++ b/src/components/app-sidebar-chat-item.tsx
@@ -37,7 +37,7 @@ export default function AppSidebarChatItem({ chat }: Props) {
 				<SidebarMenuButton
 					isActive={isActive}
 					tooltip={chat.title}
-					className="w-full"
+					className="w-full cursor-pointer"
 				>
 					{chat.isBranched && <BranchedChatIndicator chat={chat} />}
 					<span className="line-clamp-1 flex-1" title={chat.title}>

--- a/src/components/unpinned-chats-list.tsx
+++ b/src/components/unpinned-chats-list.tsx
@@ -2,6 +2,7 @@ import { convexQuery } from "@convex-dev/react-query";
 import { ChatIcon } from "@phosphor-icons/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { api } from "convex/_generated/api";
+import { groupChatsByDate } from "~/lib/group-chats-by-date";
 import AppSidebarChatItem from "./app-sidebar-chat-item";
 import DeleteAllChatsAlertDialog from "./delete-all-chats-alert-dialog";
 import { SidebarGroup, SidebarMenu } from "./ui/sidebar";
@@ -10,6 +11,8 @@ export default function UnpinnedChatsList() {
 	const { data: chats } = useSuspenseQuery(
 		convexQuery(api.chats.getUnpinnedChats, {}),
 	);
+
+	const chatsGroupedByDateRanges = groupChatsByDate(chats);
 
 	return (
 		<SidebarGroup className="space-y-1 group-data-[collapsible=icon]:hidden">
@@ -22,17 +25,21 @@ export default function UnpinnedChatsList() {
 				</div>
 				{chats.length > 0 && <DeleteAllChatsAlertDialog />}
 			</div>
-			<SidebarMenu className="gap-0.5">
-				{chats.length === 0 && (
-					<p className="px-2 py-2 text-xs text-sidebar-foreground/70">
-						No chats
-					</p>
-				)}
-				{chats.length !== 0 &&
-					chats.map((chat) => (
-						<AppSidebarChatItem chat={chat} key={chat._id} />
-					))}
-			</SidebarMenu>
+			{chats.length === 0 && (
+				<p className="px-2 py-2 text-xs text-sidebar-foreground/70">No chats</p>
+			)}
+			{chatsGroupedByDateRanges.map(({ group, chats: groupChats }) => (
+				<div key={group}>
+					<div className="px-2 pt-2 pb-0.5 text-[10px] font-medium tracking-wide text-sidebar-foreground/50 uppercase">
+						{group}
+					</div>
+					<SidebarMenu className="gap-0.5">
+						{groupChats.map((chat) => (
+							<AppSidebarChatItem chat={chat} key={chat._id} />
+						))}
+					</SidebarMenu>
+				</div>
+			))}
 		</SidebarGroup>
 	);
 }

--- a/src/lib/group-chats-by-date.ts
+++ b/src/lib/group-chats-by-date.ts
@@ -1,0 +1,75 @@
+type ChatWithCreationTime = {
+	_creationTime: number;
+};
+
+type DateGroup =
+	| "Today"
+	| "Yesterday"
+	| "Last 7 Days"
+	| "Last 30 Days"
+	| "This Year"
+	| "Older";
+
+const DATE_GROUPS: DateGroup[] = [
+	"Today",
+	"Yesterday",
+	"Last 7 Days",
+	"Last 30 Days",
+	"This Year",
+	"Older",
+];
+
+function startOfDay(date: Date): Date {
+	const d = new Date(date);
+	d.setHours(0, 0, 0, 0);
+	return d;
+}
+
+function startOfYear(date: Date): Date {
+	return new Date(date.getFullYear(), 0, 1);
+}
+
+function getDateGroup(chatTime: number, now: Date): DateGroup {
+	const todayStart = startOfDay(now).getTime();
+	const yesterdayStart = startOfDay(
+		new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1),
+	).getTime();
+	const last7DaysStart = startOfDay(
+		new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7),
+	).getTime();
+	const last30DaysStart = startOfDay(
+		new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30),
+	).getTime();
+	const thisYearStart = startOfYear(now).getTime();
+
+	if (chatTime >= todayStart) return "Today";
+	if (chatTime >= yesterdayStart) return "Yesterday";
+	if (chatTime >= last7DaysStart) return "Last 7 Days";
+	if (chatTime >= last30DaysStart) return "Last 30 Days";
+	if (chatTime >= thisYearStart) return "This Year";
+	return "Older";
+}
+
+export function groupChatsByDate<T extends ChatWithCreationTime>(
+	chats: T[],
+	now: Date = new Date(),
+): { group: DateGroup; chats: T[] }[] {
+	const groups = new Map<DateGroup, T[]>();
+
+	for (const chat of chats) {
+		const group = getDateGroup(chat._creationTime, now);
+		const existing = groups.get(group);
+		if (existing) {
+			existing.push(chat);
+		} else {
+			groups.set(group, [chat]);
+		}
+	}
+
+	return DATE_GROUPS.filter((g) => groups.has(g)).map((g) => ({
+		group: g,
+		chats: groups.get(g)!,
+	}));
+}
+
+export { DATE_GROUPS, type DateGroup };


### PR DESCRIPTION
Fixes #81 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups unpinned chats by date in the sidebar (Today, Yesterday, Last 7 Days, Last 30 Days, This Year, Older) to make history easier to scan. Fixes #81.

- **New Features**
  - Added `groupChatsByDate` utility to bucket chats by creation time in a fixed order.
  - Updated `UnpinnedChatsList` to render grouped headers and chat items; preserves the empty state.
  - Minor UI: set `cursor-pointer` on chat items for clearer interactivity.

<sup>Written for commit f2f4c94ced7a0aacb58ab7c1c5026b2063301f06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

