### PR TITLE
Reasoning loading indicator

### DIFF
--- a/src/components/ai-response-reasoning.tsx
+++ b/src/components/ai-response-reasoning.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export default function AIResponseReasoning(props: Props) {
-	const [showReasoning, setShowReasoning] = useState(true);
+	const [showReasoning, setShowReasoning] = useState(false);
 	const reasoningPart = props.parts.find((part) => part.type === "reasoning");
 
 	const toggleReasoningDisplay = () => {
@@ -21,12 +21,15 @@ export default function AIResponseReasoning(props: Props) {
 		return null;
 	}
 
+	const isStreaming =
+		"state" in reasoningPart && reasoningPart.state === "streaming";
+
 	return (
 		<div className="space-y-2">
 			<ReasoningToggleButton
+				isStreaming={isStreaming}
 				showReasoning={showReasoning}
 				toggleReasoningDisplay={toggleReasoningDisplay}
-				messageContent={props.messageContent}
 			/>
 
 			{showReasoning && (

--- a/src/components/reasoning-toggle-button.tsx
+++ b/src/components/reasoning-toggle-button.tsx
@@ -2,12 +2,13 @@ import {
 	BrainIcon,
 	CaretDownIcon,
 	CaretRightIcon,
+	SpinnerGapIcon,
 } from "@phosphor-icons/react";
 
 type Props = {
+	isStreaming: boolean;
 	toggleReasoningDisplay: () => void;
 	showReasoning: boolean;
-	messageContent: string;
 };
 
 export default function ReasoningToggleButton(props: Props) {
@@ -25,6 +26,9 @@ export default function ReasoningToggleButton(props: Props) {
 			<div className="flex items-center gap-2 font-mono text-xs text-muted-foreground select-none">
 				<BrainIcon className="size-3" />
 				<div>Reasoning</div>
+				{props.isStreaming && (
+					<SpinnerGapIcon className="size-3 animate-spin" />
+				)}
 			</div>
 		</div>
 	);

--- a/src/routes/api.chat.ts
+++ b/src/routes/api.chat.ts
@@ -277,11 +277,12 @@ export const Route = createFileRoute("/api/chat")({
 					temperature: 0.7,
 					experimental_transform: smoothStream({ chunking: "line" }),
 					abortSignal: request.signal,
-					...(isWebSearchEnabled && {
-						tools: {
-							google_search: google.tools.googleSearch({}) as any,
-						},
-					}),
+					...(isWebSearchEnabled &&
+						requestModel.openRouterModelId.startsWith("google") && {
+							tools: {
+								google_search: google.tools.googleSearch({}) as any,
+							},
+						}),
 				});
 
 				return result.toUIMessageStreamResponse({


### PR DESCRIPTION
Fixes #73 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a loading spinner on the Reasoning toggle while reasoning is streaming and hides reasoning by default. Also restricts the Google Search tool to Google models when web search is enabled to prevent incorrect tool calls.

- **New Features**
  - Show a spinner on the Reasoning toggle when the reasoning part state is streaming.
  - Reasoning is collapsed by default.

- **Bug Fixes**
  - Only include the `google_search` tool when web search is enabled and the model ID starts with `google`.

<sup>Written for commit fd6dede191ea96ce554a0a7bcf515626433aec18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

