### PR TITLE
Fix pdf renderer

### DIFF
--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -1,6 +1,6 @@
 import { ArrowSquareOutIcon, FilePdfIcon, XIcon } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { getFileUrl } from "~/server-fns/get-file-url";
 import { Button } from "./ui/button";
@@ -63,6 +63,14 @@ export default function PdfAttachmentPreview({
 
 		return "about:blank";
 	}, [attachment.url]);
+
+	useEffect(() => {
+		return () => {
+			if (inlinePdfUrl.startsWith("blob:")) {
+				URL.revokeObjectURL(inlinePdfUrl);
+			}
+		};
+	}, [inlinePdfUrl]);
 
 	const handleOpenInNewTab = async () => {
 		const newTab = window.open("", "_blank");

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -1,5 +1,6 @@
 import { ArrowSquareOutIcon, FilePdfIcon, XIcon } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
+import { useMemo } from "react";
 import { toast } from "sonner";
 import { getFileUrl } from "~/server-fns/get-file-url";
 import { Button } from "./ui/button";
@@ -40,9 +41,28 @@ export default function PdfAttachmentPreview({
 	label: string;
 	onRemove?: (index: number) => void;
 }) {
-	const inlinePdfUrl = isSafeBrowserUrl(attachment.url)
-		? attachment.url
-		: "about:blank";
+	const inlinePdfUrl = useMemo(() => {
+		if (isSafeBrowserUrl(attachment.url)) {
+			return attachment.url;
+		}
+
+		if (attachment.url.startsWith("data:")) {
+			try {
+				const byteString = atob(attachment.url.split(",")[1]);
+				const mimeMatch = attachment.url.match(/data:([^;]+)/);
+				const mime = mimeMatch?.[1] ?? "application/pdf";
+				const ab = new Uint8Array(byteString.length);
+				for (let i = 0; i < byteString.length; i++) {
+					ab[i] = byteString.charCodeAt(i);
+				}
+				return URL.createObjectURL(new Blob([ab], { type: mime }));
+			} catch {
+				return "about:blank";
+			}
+		}
+
+		return "about:blank";
+	}, [attachment.url]);
 
 	const handleOpenInNewTab = async () => {
 		const newTab = window.open("", "_blank");

--- a/src/components/pdf-attachment-preview.tsx
+++ b/src/components/pdf-attachment-preview.tsx
@@ -66,12 +66,11 @@ export default function PdfAttachmentPreview({
 
 	useEffect(() => {
 		return () => {
-			if (inlinePdfUrl.startsWith("blob:")) {
+			if (attachment.url.startsWith("data:") && inlinePdfUrl.startsWith("blob:")) {
 				URL.revokeObjectURL(inlinePdfUrl);
 			}
 		};
-	}, [inlinePdfUrl]);
-
+	}, [attachment.url, inlinePdfUrl]);
 	const handleOpenInNewTab = async () => {
 		const newTab = window.open("", "_blank");
 

--- a/src/components/text-file-attachment-preview.tsx
+++ b/src/components/text-file-attachment-preview.tsx
@@ -107,7 +107,7 @@ export default function TextFileAttachmentPreview({
 					render={
 						<button
 							type="button"
-							className="flex w-full min-w-0 items-center gap-3 rounded-[inherit] text-left outline-none focus:outline-none"
+							className="flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-[inherit] text-left outline-none focus:outline-none"
 						>
 							<div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80">
 								<FileTextIcon className="text-muted-foreground" />


### PR DESCRIPTION
Fixes #80 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken PDF previews by converting `data:` URLs to Blob URLs and blocking unsafe URLs. Also adds a cursor pointer to text file preview items.

- **Bug Fixes**
  - Render PDFs from `data:` URLs via object URLs; revoke blob URLs on recompute and unmount to clean up `data:` attachments; unsafe URLs fall back to `about:blank`.
  - Add `cursor-pointer` to text file preview row for better click affordance.

<sup>Written for commit f1ef30101a4b9491baf5dbbe846e259a05ae7836. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

