### PR TITLE
Fix stop effect on UI

### DIFF
--- a/src/components/ai-response-reasoning.tsx
+++ b/src/components/ai-response-reasoning.tsx
@@ -1,3 +1,4 @@
+import type { ChatStatus } from "ai";
 import { useState } from "react";
 import type { CustomUIMessage } from "~/types";
 import ReasoningMarkdown from "./reasoning-markdown";
@@ -7,6 +8,7 @@ type Props = {
 	parts: CustomUIMessage["parts"];
 	messageContent: string;
 	messageId: string;
+	status?: ChatStatus;
 };
 
 export default function AIResponseReasoning(props: Props) {
@@ -22,7 +24,9 @@ export default function AIResponseReasoning(props: Props) {
 	}
 
 	const isStreaming =
-		"state" in reasoningPart && reasoningPart.state === "streaming";
+		"state" in reasoningPart &&
+		reasoningPart.state === "streaming" &&
+		(props.status === "streaming" || props.status === "submitted");
 
 	return (
 		<div className="space-y-2">

--- a/src/components/assistant-message.tsx
+++ b/src/components/assistant-message.tsx
@@ -1,5 +1,6 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { CopyIcon, CpuIcon, GlobeIcon } from "@phosphor-icons/react";
+import type { ChatStatus } from "ai";
 import React from "react";
 import { toast } from "sonner";
 import { formatTokens } from "~/lib/format-tokens";
@@ -22,10 +23,11 @@ type Props = {
 	isGeneratingImage?: boolean;
 	message: CustomUIMessage;
 	regenerate?: UseChatHelpers<CustomUIMessage>["regenerate"];
+	status: ChatStatus;
 };
 
 export default React.memo(function AssistantMessage(props: Props) {
-	const { isGeneratingImage = false, message, regenerate } = props;
+	const { isGeneratingImage = false, message, regenerate, status } = props;
 	const showTokenUsage = useAppearanceStore((store) => store.showTokenUsage);
 	const isImageMessage =
 		isGeneratingImage ||
@@ -38,6 +40,10 @@ export default React.memo(function AssistantMessage(props: Props) {
 	);
 
 	if (message.parts.length === 0 || (isImageMessage && !hasRenderableParts)) {
+		const isChatActive = status === "streaming" || status === "submitted";
+		if (!isChatActive) {
+			return null;
+		}
 		return (
 			<div className="px-3 lg:px-0">
 				{isImageMessage ? <ImageGenerationSkeleton /> : <ThinkingIndicator />}
@@ -53,6 +59,7 @@ export default React.memo(function AssistantMessage(props: Props) {
 				messageContent={messageContent}
 				messageId={message.id}
 				parts={message.parts}
+				status={status}
 			/>
 			<AIResponseContent
 				messageContent={messageContent}

--- a/src/components/assistant-message.tsx
+++ b/src/components/assistant-message.tsx
@@ -1,5 +1,5 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
-import { CopyIcon, CpuIcon, GlobeIcon } from "@phosphor-icons/react";
+import { CopyIcon, CpuIcon, GlobeIcon, StopIcon } from "@phosphor-icons/react";
 import type { ChatStatus } from "ai";
 import React from "react";
 import { toast } from "sonner";
@@ -16,6 +16,7 @@ import BranchOffButton from "./branch-off-button";
 import ImageGenerationSkeleton from "./image-generation-skeleton";
 import RetryModelDropdown from "./retry-model-dropdown";
 import ThinkingIndicator from "./thinking-indicator";
+import { Alert, AlertDescription } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -24,10 +25,17 @@ type Props = {
 	message: CustomUIMessage;
 	regenerate?: UseChatHelpers<CustomUIMessage>["regenerate"];
 	status: ChatStatus;
+	wasStopped: boolean;
 };
 
 export default React.memo(function AssistantMessage(props: Props) {
-	const { isGeneratingImage = false, message, regenerate, status } = props;
+	const {
+		isGeneratingImage = false,
+		message,
+		regenerate,
+		status,
+		wasStopped,
+	} = props;
 	const showTokenUsage = useAppearanceStore((store) => store.showTokenUsage);
 	const isImageMessage =
 		isGeneratingImage ||
@@ -38,10 +46,18 @@ export default React.memo(function AssistantMessage(props: Props) {
 	const hasRenderableParts = message.parts.some(
 		(part) => part.type !== "step-start",
 	);
+	const isChatActive = status === "streaming" || status === "submitted";
 
 	if (message.parts.length === 0 || (isImageMessage && !hasRenderableParts)) {
-		const isChatActive = status === "streaming" || status === "submitted";
 		if (!isChatActive) {
+			if (wasStopped) {
+				return (
+					<Alert className="mb-8 border-border">
+						<StopIcon />
+						<AlertDescription>Generation stopped.</AlertDescription>
+					</Alert>
+				);
+			}
 			return null;
 		}
 		return (
@@ -67,6 +83,13 @@ export default React.memo(function AssistantMessage(props: Props) {
 			/>
 			<AIGeneratedImages parts={message.parts} />
 			<AIResponseSources parts={message.parts} />
+
+			{wasStopped && !isChatActive && (
+				<Alert className="border-border">
+					<StopIcon />
+					<AlertDescription>Generation stopped.</AlertDescription>
+				</Alert>
+			)}
 
 			{/* Message actions - visible on mobile, hover on desktop */}
 			<div className="flex items-center gap-6 opacity-100 transition-opacity duration-200 md:opacity-0 md:group-hover:opacity-100">

--- a/src/components/chat-messages.tsx
+++ b/src/components/chat-messages.tsx
@@ -13,6 +13,7 @@ type Props = {
 	regenerate: UseChatHelpers<CustomUIMessage>["regenerate"];
 	sendMessage: UseChatHelpers<CustomUIMessage>["sendMessage"];
 	status: ChatStatus;
+	wasStopped: boolean;
 };
 
 export default memo(function ChatMessages({
@@ -23,6 +24,7 @@ export default memo(function ChatMessages({
 	regenerate,
 	sendMessage,
 	status,
+	wasStopped,
 }: Props) {
 	if (messages.length === 0) {
 		return null;
@@ -47,6 +49,7 @@ export default memo(function ChatMessages({
 							message={message}
 							regenerate={regenerate}
 							status={status}
+							wasStopped={wasStopped}
 						/>
 					)}
 				</div>

--- a/src/components/chat-messages.tsx
+++ b/src/components/chat-messages.tsx
@@ -1,4 +1,5 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
+import type { ChatStatus } from "ai";
 import { memo } from "react";
 import type { CustomUIMessage } from "~/types";
 import AssistantMessage from "./assistant-message";
@@ -11,6 +12,7 @@ type Props = {
 	messages: CustomUIMessage[];
 	regenerate: UseChatHelpers<CustomUIMessage>["regenerate"];
 	sendMessage: UseChatHelpers<CustomUIMessage>["sendMessage"];
+	status: ChatStatus;
 };
 
 export default memo(function ChatMessages({
@@ -20,6 +22,7 @@ export default memo(function ChatMessages({
 	messages,
 	regenerate,
 	sendMessage,
+	status,
 }: Props) {
 	if (messages.length === 0) {
 		return null;
@@ -43,6 +46,7 @@ export default memo(function ChatMessages({
 							isGeneratingImage={isGeneratingImage}
 							message={message}
 							regenerate={regenerate}
+							status={status}
 						/>
 					)}
 				</div>

--- a/src/components/chat-messages.tsx
+++ b/src/components/chat-messages.tsx
@@ -49,7 +49,12 @@ export default memo(function ChatMessages({
 							message={message}
 							regenerate={regenerate}
 							status={status}
-							wasStopped={wasStopped}
+							// Only the last assistant message was the one being generated
+							// when stop was clicked — older ones should not show the alert.
+							wasStopped={
+								wasStopped &&
+								!messages.slice(index + 1).some((m) => m.role === "assistant")
+							}
 						/>
 					)}
 				</div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -53,6 +53,12 @@ export default function Chat({
 	const viewportRef = useRef<HTMLDivElement>(null);
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 	const [inputHeight, setInputHeight] = useState(120); // Default estimate
+	const [wasStopped, setWasStopped] = useState(false);
+
+	const handleStop = () => {
+		setWasStopped(true);
+		return stop();
+	};
 
 	const checkScrollPosition = () => {
 		const viewport = viewportRef.current;
@@ -142,6 +148,7 @@ export default function Chat({
 											regenerate={regenerate}
 											sendMessage={sendMessage}
 											status={status}
+											wasStopped={wasStopped}
 										/>
 
 										{status === "submitted" &&
@@ -185,7 +192,7 @@ export default function Chat({
 					latestGeneratedImageUrl={latestGeneratedImageUrl}
 					sendMessage={sendMessage}
 					status={status}
-					stop={stop}
+					stop={handleStop}
 					onHeightChange={setInputHeight}
 				/>
 			</div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -5,7 +5,11 @@ import { useEffect, useRef, useState } from "react";
 import { isImageGenerationModel } from "~/lib/is-image-generation-model";
 import { useSharedChatContext } from "~/providers/chat-provider";
 import { useModelStore } from "~/stores/model-store";
-import type { ChatSendMessage, CustomUIMessage } from "~/types";
+import type {
+	ChatRegenerateFunction,
+	ChatSendMessageFunction,
+	CustomUIMessage,
+} from "~/types";
 import AiResponseAlert from "./ai-response-error";
 import AssistantMessageSkeleton from "./assistant-message-skeleton";
 import ChatMessages from "./chat-messages";
@@ -60,11 +64,18 @@ export default function Chat({
 		return stop();
 	};
 
-	const handleSendMessage: ChatSendMessage = (
-		...args: Parameters<ChatSendMessage>
+	const handleSendMessage: ChatSendMessageFunction = (
+		...args: Parameters<ChatSendMessageFunction>
 	) => {
 		setWasStopped(false);
 		return sendMessage(...args);
+	};
+
+	const handleRegenerate: ChatRegenerateFunction = (
+		...args: Parameters<ChatRegenerateFunction>
+	) => {
+		setWasStopped(false);
+		return regenerate(...args);
 	};
 
 	const checkScrollPosition = () => {
@@ -152,7 +163,7 @@ export default function Chat({
 											isGeneratingImage={isGeneratingImage}
 											latestGeneratedImageUrl={latestGeneratedImageUrl}
 											messages={messages}
-											regenerate={regenerate}
+											regenerate={handleRegenerate}
 											sendMessage={handleSendMessage}
 											status={status}
 											wasStopped={wasStopped}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -105,6 +105,7 @@ export default function Chat({
 			setMessages(dbMessages);
 		}
 	}, [setMessages, dbMessages, isMessagesPending]);
+
 	const isGeneratingImage = isImageGenerationModel(selectedModel);
 	const latestGeneratedImageUrl =
 		[...messages]
@@ -140,6 +141,7 @@ export default function Chat({
 											messages={messages}
 											regenerate={regenerate}
 											sendMessage={sendMessage}
+											status={status}
 										/>
 
 										{status === "submitted" &&

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { isImageGenerationModel } from "~/lib/is-image-generation-model";
 import { useSharedChatContext } from "~/providers/chat-provider";
 import { useModelStore } from "~/stores/model-store";
-import type { CustomUIMessage } from "~/types";
+import type { ChatSendMessage, CustomUIMessage } from "~/types";
 import AiResponseAlert from "./ai-response-error";
 import AssistantMessageSkeleton from "./assistant-message-skeleton";
 import ChatMessages from "./chat-messages";
@@ -58,6 +58,13 @@ export default function Chat({
 	const handleStop = () => {
 		setWasStopped(true);
 		return stop();
+	};
+
+	const handleSendMessage: ChatSendMessage = (
+		...args: Parameters<ChatSendMessage>
+	) => {
+		setWasStopped(false);
+		return sendMessage(...args);
 	};
 
 	const checkScrollPosition = () => {
@@ -146,7 +153,7 @@ export default function Chat({
 											latestGeneratedImageUrl={latestGeneratedImageUrl}
 											messages={messages}
 											regenerate={regenerate}
-											sendMessage={sendMessage}
+											sendMessage={handleSendMessage}
 											status={status}
 											wasStopped={wasStopped}
 										/>
@@ -190,7 +197,7 @@ export default function Chat({
 				<UserPromptInput
 					chatId={chatId}
 					latestGeneratedImageUrl={latestGeneratedImageUrl}
-					sendMessage={sendMessage}
+					sendMessage={handleSendMessage}
 					status={status}
 					stop={handleStop}
 					onHeightChange={setInputHeight}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { UIMessage, UseChatHelpers } from "@ai-sdk/react";
 import type { api } from "convex/_generated/api";
 import type { FunctionReturnType } from "convex/server";
 import { z } from "zod";
@@ -68,3 +68,5 @@ export type CustomUIMessage = Omit<UIMessage<MessageMetadata>, "role"> & {
 };
 
 export type AppFont = "font-mono" | "font-sans";
+
+export type ChatSendMessage = UseChatHelpers<CustomUIMessage>["sendMessage"];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,4 +69,8 @@ export type CustomUIMessage = Omit<UIMessage<MessageMetadata>, "role"> & {
 
 export type AppFont = "font-mono" | "font-sans";
 
-export type ChatSendMessage = UseChatHelpers<CustomUIMessage>["sendMessage"];
+export type ChatSendMessageFunction =
+	UseChatHelpers<CustomUIMessage>["sendMessage"];
+
+export type ChatRegenerateFunction =
+	UseChatHelpers<CustomUIMessage>["regenerate"];


### PR DESCRIPTION
Fixes #95 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat UI when a generation is stopped. Shows a clear “Generation stopped.” message only for the interrupted reply and halts streaming visuals.

- **Bug Fixes**
  - Added `wasStopped` state in `Chat`; wrapped `stop`, `sendMessage`, and `regenerate` to set/clear it so the alert doesn’t persist into new replies.
  - Passed `status` (`ai` `ChatStatus`) and `wasStopped` through `Chat` → `ChatMessages` → `AssistantMessage` and `AIResponseReasoning`.
  - Gated streaming/rendering on `status` being `streaming` or `submitted`; show the stop alert only on the last interrupted assistant message.

<sup>Written for commit 1025227a721531b7505f77c88876087b35550e6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

