### PR TITLE
add input for custom instructions

### DIFF
--- a/src/components/branch-off-button.tsx
+++ b/src/components/branch-off-button.tsx
@@ -11,6 +11,7 @@ import { api } from "convex/_generated/api";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { getAccessibleModels } from "~/lib/get-accessible-models";
 import { useSharedChatContext } from "~/providers/chat-provider";
+import { useCustomizationStore } from "~/stores/customization-store";
 import { modelStoreActions, useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage, Model } from "~/types";
@@ -47,6 +48,9 @@ export default function BranchOffButton({ message, sendMessage }: Props) {
 	);
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
 		(store) => store.persistedUseOpenRouter,
+	);
+	const customSystemPrompt = useCustomizationStore(
+		(store) => store.customSystemPrompt,
 	);
 	const accessibleModels = getAccessibleModels(
 		persistedApiKeys,
@@ -107,6 +111,7 @@ export default function BranchOffButton({ message, sendMessage }: Props) {
 						apiKeys: persistedApiKeys,
 						useOpenRouter: persistedUseOpenRouter,
 						chatId: branchChatUuid,
+						customSystemPrompt,
 					},
 				},
 			);

--- a/src/components/customization-settings.tsx
+++ b/src/components/customization-settings.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+import { TabsContent } from "~/components/ui/tabs";
+import { Textarea } from "~/components/ui/textarea";
+import {
+	customizationStoreActions,
+	useCustomizationStore,
+} from "~/stores/customization-store";
+
+export default function CustomizationSettings() {
+	const persistedPrompt = useCustomizationStore(
+		(store) => store.customSystemPrompt,
+	);
+	const [draft, setDraft] = useState(persistedPrompt);
+
+	const handleSave = () => {
+		customizationStoreActions.setCustomSystemPrompt(draft);
+		toast.success("Custom system prompt saved");
+	};
+
+	return (
+		<TabsContent className="flex flex-col gap-10" value="customization">
+			{/* System Prompt */}
+			<section className="flex flex-col gap-4">
+				<header className="flex flex-col gap-1">
+					<h2 className="text-base font-semibold">System Prompt</h2>
+					<p className="text-sm text-muted-foreground">
+						Add a custom system prompt that will be appended to the default
+						system instructions sent with every message
+					</p>
+				</header>
+
+				<div className="rounded-lg border bg-card p-4">
+					<div className="flex flex-col gap-2">
+						<Label className="font-medium" htmlFor="custom-system-prompt">
+							Custom prompt
+						</Label>
+						<Textarea
+							className="min-h-32 resize-y"
+							id="custom-system-prompt"
+							onChange={(e) => setDraft(e.target.value)}
+							placeholder="e.g. Always respond in Spanish, or use a formal tone..."
+							value={draft}
+						/>
+						<p className="text-xs text-muted-foreground">
+							This prompt will be added after the default system instructions.
+							Leave empty to use only the defaults.
+						</p>
+					</div>
+				</div>
+
+				<Button onClick={handleSave}>Save</Button>
+			</section>
+		</TabsContent>
+	);
+}

--- a/src/components/retry-model-dropdown.tsx
+++ b/src/components/retry-model-dropdown.tsx
@@ -6,6 +6,7 @@ import { useParams } from "@tanstack/react-router";
 import { api } from "convex/_generated/api";
 import { getAccessibleModels } from "~/lib/get-accessible-models";
 import { getModelByOpenRouterId } from "~/lib/get-model-by-id";
+import { useCustomizationStore } from "~/stores/customization-store";
 import { modelStoreActions, useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage, Model } from "~/types";
@@ -43,6 +44,9 @@ export default function RetryModelDropdown(props: Props) {
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
 		(store) => store.persistedUseOpenRouter,
 	);
+	const customSystemPrompt = useCustomizationStore(
+		(store) => store.customSystemPrompt,
+	);
 
 	const accessibleModels = getAccessibleModels(
 		persistedApiKeys,
@@ -76,6 +80,7 @@ export default function RetryModelDropdown(props: Props) {
 				apiKeys: persistedApiKeys,
 				useOpenRouter: persistedUseOpenRouter,
 				chatId,
+				customSystemPrompt,
 			},
 		});
 	};

--- a/src/components/user-message.tsx
+++ b/src/components/user-message.tsx
@@ -10,6 +10,7 @@ import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { getFilePartsFromMessage } from "~/lib/get-file-parts-from-message";
 import { getMessageContentFromParts } from "~/lib/get-message-content-from-parts";
 import { cn } from "~/lib/utils";
+import { useCustomizationStore } from "~/stores/customization-store";
 import { useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage } from "~/types";
@@ -49,6 +50,9 @@ export default memo(function UserMessage({
 	);
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
 		(store) => store.persistedUseOpenRouter,
+	);
+	const customSystemPrompt = useCustomizationStore(
+		(store) => store.customSystemPrompt,
 	);
 
 	const createMessageMutation = useMutation({
@@ -96,6 +100,7 @@ export default memo(function UserMessage({
 					apiKeys: persistedApiKeys,
 					useOpenRouter: persistedUseOpenRouter,
 					chatId,
+					customSystemPrompt,
 				},
 			},
 		);

--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -12,6 +12,7 @@ import { usePromptAttachments } from "~/hooks/use-prompt-attachments";
 import { buildUserMessageParts } from "~/lib/build-user-message-parts";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { getChatTitle } from "~/server-fns/get-chat-title";
+import { useCustomizationStore } from "~/stores/customization-store";
 import { useModelStore } from "~/stores/model-store";
 import { usePersistedApiKeysStore } from "~/stores/persisted-api-keys-store";
 import type { CustomUIMessage } from "~/types";
@@ -46,6 +47,9 @@ export default function UserPromptInput(props: Props) {
 	);
 	const persistedUseOpenRouter = usePersistedApiKeysStore(
 		(store) => store.persistedUseOpenRouter,
+	);
+	const customSystemPrompt = useCustomizationStore(
+		(store) => store.customSystemPrompt,
 	);
 	const {
 		attachments,
@@ -120,6 +124,7 @@ export default function UserPromptInput(props: Props) {
 						apiKeys: persistedApiKeys,
 						useOpenRouter: persistedUseOpenRouter,
 						chatId: props.chatId,
+						customSystemPrompt,
 					},
 				},
 			);

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -4,6 +4,7 @@ import ApiKeysForm from "~/components/api-keys-form";
 import AppearanceSettings from "~/components/appearance-settings";
 import ChatHistoryManager from "~/components/chat-history-manager";
 import ContactSection from "~/components/contact-section";
+import CustomizationSettings from "~/components/customization-settings";
 import { Button } from "~/components/ui/button";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
@@ -68,6 +69,12 @@ function SettingsPage() {
 								</TabsTrigger>
 								<TabsTrigger
 									className="px-2 py-1 text-xs whitespace-nowrap lg:px-3 lg:py-1.5 lg:text-sm"
+									value="customization"
+								>
+									Customization
+								</TabsTrigger>
+								<TabsTrigger
+									className="px-2 py-1 text-xs whitespace-nowrap lg:px-3 lg:py-1.5 lg:text-sm"
 									value="about"
 								>
 									Contact
@@ -80,6 +87,7 @@ function SettingsPage() {
 							<ApiKeysForm />
 							<ChatHistoryManager />
 							<AppearanceSettings />
+							<CustomizationSettings />
 							<ContactSection />
 						</div>
 					</Tabs>

--- a/src/routes/api.chat.ts
+++ b/src/routes/api.chat.ts
@@ -239,6 +239,7 @@ type ChatRequestBody = {
 	apiKeys: ApiKeys;
 	useOpenRouter: boolean;
 	chatId?: string;
+	customSystemPrompt?: string;
 };
 
 export const Route = createFileRoute("/api/chat")({
@@ -258,6 +259,7 @@ export const Route = createFileRoute("/api/chat")({
 					apiKeys,
 					useOpenRouter,
 					chatId,
+					customSystemPrompt,
 				} = chatRequestBody;
 
 				const modelToUse = resolveModelForRequest(
@@ -267,9 +269,13 @@ export const Route = createFileRoute("/api/chat")({
 					isWebSearchEnabled,
 				);
 
+				const finalSystemMessage = customSystemPrompt
+					? `${systemMessage}\n\n${customSystemPrompt}`
+					: systemMessage;
+
 				const result = streamText({
 					model: modelToUse,
-					system: systemMessage,
+					system: finalSystemMessage,
 					messages: await convertToModelMessages(
 						transformMessagesForModel(messages),
 					),

--- a/src/stores/customization-store.ts
+++ b/src/stores/customization-store.ts
@@ -1,0 +1,46 @@
+import { useSelector } from "@tanstack/react-store";
+import { Store } from "@tanstack/store";
+
+type CustomizationStoreState = {
+	customSystemPrompt: string;
+};
+
+const STORAGE_KEY = "baychat-customization-settings";
+
+const getInitialState = (): CustomizationStoreState => {
+	if (typeof window === "undefined") {
+		return { customSystemPrompt: "" };
+	}
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored) {
+			return JSON.parse(stored);
+		}
+	} catch {
+		// Ignore parse errors
+	}
+	return { customSystemPrompt: "" };
+};
+
+const customizationStore = new Store<CustomizationStoreState>(
+	getInitialState(),
+);
+
+customizationStore.subscribe(() => {
+	if (typeof window !== "undefined") {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(customizationStore.state));
+	}
+});
+
+export const useCustomizationStore = <T>(
+	selector: (state: CustomizationStoreState) => T,
+): T => useSelector(customizationStore, selector);
+
+export const customizationStoreActions = {
+	setCustomSystemPrompt: (prompt: string) => {
+		customizationStore.setState((prev) => ({
+			...prev,
+			customSystemPrompt: prompt,
+		}));
+	},
+};

--- a/src/stores/customization-store.ts
+++ b/src/stores/customization-store.ts
@@ -14,7 +14,14 @@ const getInitialState = (): CustomizationStoreState => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
 		if (stored) {
-			return JSON.parse(stored);
+			const parsed = JSON.parse(stored);
+			if (
+				parsed &&
+				typeof parsed === "object" &&
+				typeof parsed.customSystemPrompt === "string"
+			) {
+				return parsed as CustomizationStoreState;
+			}
 		}
 	} catch {
 		// Ignore parse errors
@@ -28,7 +35,14 @@ const customizationStore = new Store<CustomizationStoreState>(
 
 customizationStore.subscribe(() => {
 	if (typeof window !== "undefined") {
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(customizationStore.state));
+		try {
+			localStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify(customizationStore.state),
+			);
+		} catch {
+			// Storage unavailable (quota exceeded, private browsing, etc.)
+		}
 	}
 });
 


### PR DESCRIPTION
Fixes #86 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customizable system prompt that is appended to the default instructions for every chat. Adds a Settings > Customization tab to save it locally and apply it to send, retry, and branch actions (fixes #86).

- **New Features**
  - New Settings > Customization tab with a textarea and Save action (persisted via localStorage).
  - `customSystemPrompt` is sent with requests from `user-prompt-input`, `user-message`, `retry-model-dropdown`, and `branch-off-button`.
  - `/api/chat` appends the custom prompt after the default system message for each request.

- **Bug Fixes**
  - Safe localStorage parsing and writes to avoid errors with invalid data or restricted storage.

<sup>Written for commit 708e66c9f09e910dc0d496f1aad0ea95416b248c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

