### PR TITLE
fix shared chat title spacing

### DIFF
--- a/src/components/read-only-assistant-message.tsx
+++ b/src/components/read-only-assistant-message.tsx
@@ -35,27 +35,29 @@ export default function ReadOnlyAssistantMessage({ message }: Props) {
 			/>
 			<AIResponseSources parts={messageParts} />
 			<div className="flex items-center gap-6 opacity-100 transition-opacity duration-200 md:opacity-0 md:group-hover:opacity-100">
-				<Tooltip>
-					<TooltipTrigger
-						render={
-							<Button
-								onClick={async () => {
-									await navigator.clipboard.writeText(messageContent);
-									toast.success("Copied to clipboard");
-								}}
-								size="icon"
-								variant="ghost"
-							/>
-						}
-					>
-						<CopyIcon />
-					</TooltipTrigger>
-					<TooltipContent>Copy to clipboard</TooltipContent>
-				</Tooltip>
+				<div className="flex items-center gap-1">
+					<Tooltip>
+						<TooltipTrigger
+							render={
+								<Button
+									onClick={async () => {
+										await navigator.clipboard.writeText(messageContent);
+										toast.success("Copied to clipboard");
+									}}
+									size="icon"
+									variant="ghost"
+								/>
+							}
+						>
+							<CopyIcon />
+						</TooltipTrigger>
+						<TooltipContent>Copy to clipboard</TooltipContent>
+					</Tooltip>
 
-				<span className="text-xs text-muted-foreground">
-					{messageMetadata?.modelName}
-				</span>
+					<span className="text-xs text-muted-foreground">
+						{messageMetadata?.modelName}
+					</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/read-only-chat-messages.tsx
+++ b/src/components/read-only-chat-messages.tsx
@@ -41,7 +41,7 @@ export default function ReadOnlyChatMessages() {
 				<ScrollArea className="h-full w-full">
 					<div className="mx-auto h-full w-full max-w-3xl">
 						<div className="space-y-6 px-3 pb-32 lg:space-y-8 lg:px-0">
-							<h2 className="-mt-3 text-center text-3xl font-semibold">
+							<h2 className="pt-6 text-center text-3xl font-semibold">
 								{data?.parentChatTitle}
 							</h2>
 


### PR DESCRIPTION
Fixes #99 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uneven spacing in shared chat views by adjusting the title layout and aligning the assistant message actions for better readability.

- **Bug Fixes**
  - Replaced `-mt-3` with `pt-6` on the shared chat title to ensure consistent top spacing.
  - Wrapped the copy button and model name in a small-gap `flex` row to align them cleanly.

<sup>Written for commit e0e232e95300120d6fd42dd343c50c8d6d232e1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

