### PR TITLE
Hide scroll to bottom button

### DIFF
--- a/src/components/ai-response-content.tsx
+++ b/src/components/ai-response-content.tsx
@@ -11,7 +11,7 @@ export default function AIResponseContent({
 }: Props) {
 	return (
 		<div className="relative px-0 lg:-mx-2 lg:px-2">
-			<div className="prose prose-sm w-full max-w-full leading-7 wrap-break-word prose-neutral prose-rose select-text lg:leading-8 dark:prose-invert prose-pre:bg-transparent prose-pre:p-0 [&_pre]:overflow-x-auto [&_table]:block [&_table]:overflow-x-auto">
+			<div className="prose prose-sm w-full max-w-full leading-7 wrap-break-word prose-neutral prose-amber select-text lg:leading-8 dark:prose-invert prose-pre:bg-transparent prose-pre:p-0 [&_pre]:overflow-x-auto [&_table]:block [&_table]:overflow-x-auto">
 				<MemoizedMarkdown content={messageContent} id={messageId} />
 			</div>
 		</div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -3,6 +3,7 @@ import { CaretDownIcon } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
 import { useEffect, useRef, useState } from "react";
 import { isImageGenerationModel } from "~/lib/is-image-generation-model";
+import { cn } from "~/lib/utils";
 import { useSharedChatContext } from "~/providers/chat-provider";
 import { useModelStore } from "~/stores/model-store";
 import type {
@@ -206,9 +207,12 @@ export default function Chat({
 			</div>
 
 			{/* Scroll to bottom button - centered at top of prompt */}
-			{showScrollToBottom && isScrollActive && (
+			{showScrollToBottom && (
 				<div
-					className="absolute left-1/2 z-50 -translate-x-1/2 transform"
+					className={cn(
+						"absolute left-1/2 z-50 -translate-x-1/2 transform transition-opacity duration-300 ease-in-out",
+						isScrollActive ? "opacity-100" : "pointer-events-none opacity-0",
+					)}
 					style={{ bottom: `${inputHeight + 16}px` }}
 				>
 					<Button className="rounded-full" onClick={scrollToBottom} size="icon">

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -215,7 +215,13 @@ export default function Chat({
 					)}
 					style={{ bottom: `${inputHeight + 16}px` }}
 				>
-					<Button className="rounded-full" onClick={scrollToBottom} size="icon">
+					<Button
+						className="rounded-full"
+						onClick={scrollToBottom}
+						size="icon"
+						tabIndex={isScrollActive ? undefined : -1}
+						aria-hidden={!isScrollActive}
+					>
 						<CaretDownIcon />
 					</Button>
 				</div>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -56,6 +56,8 @@ export default function Chat({
 
 	const viewportRef = useRef<HTMLDivElement>(null);
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+	const [isScrollActive, setIsScrollActive] = useState(false);
+	const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [inputHeight, setInputHeight] = useState(120); // Default estimate
 	const [wasStopped, setWasStopped] = useState(false);
 
@@ -92,6 +94,15 @@ export default function Chat({
 			scrollTop + clientHeight >= scrollHeight - bottomThreshold;
 
 		setShowScrollToBottom(isScrollable && !isNearBottom);
+		setIsScrollActive(true);
+
+		if (scrollTimeoutRef.current) {
+			clearTimeout(scrollTimeoutRef.current);
+		}
+
+		scrollTimeoutRef.current = setTimeout(() => {
+			setIsScrollActive(false);
+		}, 2000);
 	};
 
 	const scrollToBottom = () => {
@@ -119,6 +130,9 @@ export default function Chat({
 
 		return () => {
 			viewport.removeEventListener("scroll", checkScrollPosition);
+			if (scrollTimeoutRef.current) {
+				clearTimeout(scrollTimeoutRef.current);
+			}
 		};
 	}, [messages]);
 
@@ -192,7 +206,7 @@ export default function Chat({
 			</div>
 
 			{/* Scroll to bottom button - centered at top of prompt */}
-			{showScrollToBottom && (
+			{showScrollToBottom && isScrollActive && (
 				<div
 					className="absolute left-1/2 z-50 -translate-x-1/2 transform"
 					style={{ bottom: `${inputHeight + 16}px` }}

--- a/src/components/reasoning-markdown.tsx
+++ b/src/components/reasoning-markdown.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function ReasoningMarkdown(props: Props) {
 	return (
-		<div className="prose w-full max-w-full rounded-md border bg-popover p-4 font-mono text-xs leading-6 prose-neutral prose-rose dark:prose-invert prose-pre:m-0 prose-pre:bg-transparent prose-pre:p-0">
+		<div className="prose w-full max-w-full rounded-md border bg-popover p-4 font-mono text-xs leading-6 prose-neutral prose-amber dark:prose-invert prose-pre:m-0 prose-pre:bg-transparent prose-pre:p-0">
 			<MemoizedMarkdown content={props.reasoningContent} id={props.messageId} />
 		</div>
 	);


### PR DESCRIPTION
Fixes #101 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-hide and fade the “Scroll to bottom” button to reduce UI clutter; switch prose theme to amber for AI and reasoning markdown. Fixes #101.

- **New Features**
  - Button shows while scrolling when not near the bottom; fades out after 2s idle. Hidden state disables pointer events, sets `tabIndex=-1`, and uses `aria-hidden`.
  - Adds cleanup for scroll and timeout handlers.
  - Updates `prose-rose` to `prose-amber` in `AIResponseContent` and `ReasoningMarkdown`.

<sup>Written for commit 347b4e3ac1d41f54ab88b5099fd6407b6d465763. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

