### PR TITLE
Archive chats

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as functions from "../functions.js";
 import type * as http from "../http.js";
 import type * as imageGenerations from "../imageGenerations.js";
 import type * as messages from "../messages.js";
+import type * as migrations_setAllChatsUnarchived from "../migrations/setAllChatsUnarchived.js";
 import type * as model_chats from "../model/chats.js";
 import type * as model_users from "../model/users.js";
 
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   imageGenerations: typeof imageGenerations;
   messages: typeof messages;
+  "migrations/setAllChatsUnarchived": typeof migrations_setAllChatsUnarchived;
   "model/chats": typeof model_chats;
   "model/users": typeof model_users;
 }>;

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -12,8 +12,8 @@ export const getChats = query({
 
 		const chats = await ctx.db
 			.query("chats")
-			.withIndex("by_user_and_pinned_and_folder_and_archived", (q) =>
-				q.eq("userId", userId),
+			.withIndex("by_user_and_archived", (q) =>
+				q.eq("userId", userId).eq("isArchived", false),
 			)
 			.order("desc")
 			.collect();
@@ -156,6 +156,24 @@ export const toggleChatPin = mutation({
 	},
 });
 
+export const getArchivedChats = query({
+	handler: async (ctx) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+
+		const chats = await ctx.db
+			.query("chats")
+			.withIndex("by_user_and_archived", (q) =>
+				q.eq("userId", userId).eq("isArchived", true),
+			)
+			.order("desc")
+			.collect();
+
+		const selectedFieldsChats = chats.map((chat) => selectChatFields(chat));
+
+		return selectedFieldsChats;
+	},
+});
+
 export const toggleChatArchive = mutation({
 	args: {
 		chatId: v.id("chats"),
@@ -171,6 +189,34 @@ export const toggleChatArchive = mutation({
 		}
 		await ctx.db.patch(args.chatId, { isArchived: !chat.isArchived });
 		return chat.isArchived;
+	},
+});
+
+export const archiveAll = mutation({
+	args: {
+		chatIds: v.array(v.id("chats")),
+	},
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		for (const chatId of args.chatIds) {
+			const chat = await ctx.db.get(chatId);
+			if (!chat || chat.userId !== userId) continue;
+			await ctx.db.patch(chatId, { isArchived: true });
+		}
+	},
+});
+
+export const unarchiveAll = mutation({
+	args: {
+		chatIds: v.array(v.id("chats")),
+	},
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		for (const chatId of args.chatIds) {
+			const chat = await ctx.db.get(chatId);
+			if (!chat || chat.userId !== userId) continue;
+			await ctx.db.patch(chatId, { isArchived: false });
+		}
 	},
 });
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -12,7 +12,9 @@ export const getChats = query({
 
 		const chats = await ctx.db
 			.query("chats")
-			.withIndex("by_user_and_pinned_and_folder", (q) => q.eq("userId", userId))
+			.withIndex("by_user_and_pinned_and_folder_and_archived", (q) =>
+				q.eq("userId", userId),
+			)
 			.order("desc")
 			.collect();
 
@@ -28,8 +30,12 @@ export const getUnpinnedChats = query({
 
 		const chats = await ctx.db
 			.query("chats")
-			.withIndex("by_user_and_pinned_and_folder", (q) =>
-				q.eq("userId", userId).eq("isPinned", false).eq("folderId", undefined),
+			.withIndex("by_user_and_pinned_and_folder_and_archived", (q) =>
+				q
+					.eq("userId", userId)
+					.eq("isPinned", false)
+					.eq("folderId", undefined)
+					.eq("isArchived", false),
 			)
 			.order("desc")
 			.collect();
@@ -62,8 +68,12 @@ export const getPinnedChats = query({
 
 		const chats = await ctx.db
 			.query("chats")
-			.withIndex("by_user_and_pinned_and_folder", (q) =>
-				q.eq("userId", userId).eq("isPinned", true).eq("folderId", undefined),
+			.withIndex("by_user_and_pinned_and_folder_and_archived", (q) =>
+				q
+					.eq("userId", userId)
+					.eq("isPinned", true)
+					.eq("folderId", undefined)
+					.eq("isArchived", false),
 			)
 			.order("desc")
 			.collect();
@@ -101,6 +111,7 @@ export const createChat = mutation({
 			title: "Generating title..",
 			isPinned: false,
 			isBranched: false,
+			isArchived: false,
 		});
 
 		return newChatId;
@@ -142,6 +153,24 @@ export const toggleChatPin = mutation({
 		}
 		await ctx.db.patch(args.chatId, { isPinned: !chat.isPinned });
 		return chat.isPinned;
+	},
+});
+
+export const toggleChatArchive = mutation({
+	args: {
+		chatId: v.id("chats"),
+	},
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		const chat = await ctx.db.get(args.chatId);
+		if (!chat) {
+			throw new Error("Invalid chat request");
+		}
+		if (chat.userId !== userId) {
+			throw new Error("Unauthorized request");
+		}
+		await ctx.db.patch(args.chatId, { isArchived: !chat.isArchived });
+		return chat.isArchived;
 	},
 });
 
@@ -318,7 +347,7 @@ export const branchOffChat = mutation({
 			userId: user,
 			uuid: args.branchedChatUuid,
 			parentChatId: parentChat._id,
-			// parentChatUuid: parentChat.uuid,
+			isArchived: false,
 		});
 
 		// get newly inserted branched chat

--- a/convex/migrations/setAllChatsUnarchived.ts
+++ b/convex/migrations/setAllChatsUnarchived.ts
@@ -1,0 +1,15 @@
+import { mutation } from "convex/_generated/server";
+
+export const setAllChatsUnarchived = mutation({
+	handler: async (ctx) => {
+		const chats = await ctx.db.query("chats").collect();
+
+		await Promise.all(
+			chats.map((chat) => {
+				ctx.db.patch("chats", chat._id, {
+					isArchived: false,
+				});
+			}),
+		);
+	},
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -25,10 +25,16 @@ export default defineSchema({
 		isBranched: v.boolean(),
 		parentChatId: v.optional(v.id("chats")),
 		folderId: v.optional(v.id("folders")),
+		isArchived: v.boolean(),
 	})
 		.index("by_chat_uuid", ["uuid"])
 		.index("by_user", ["userId"])
-		.index("by_user_and_pinned_and_folder", ["userId", "isPinned", "folderId"])
+		.index("by_user_and_pinned_and_folder_and_archived", [
+			"userId",
+			"isPinned",
+			"folderId",
+			"isArchived",
+		])
 		.index("by_folder_and_user", ["userId", "folderId"]),
 
 	messages: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -25,7 +25,7 @@ export default defineSchema({
 		isBranched: v.boolean(),
 		parentChatId: v.optional(v.id("chats")),
 		folderId: v.optional(v.id("folders")),
-		isArchived: v.boolean(),
+		isArchived: v.optional(v.boolean()),
 	})
 		.index("by_chat_uuid", ["uuid"])
 		.index("by_user", ["userId"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -35,6 +35,7 @@ export default defineSchema({
 			"folderId",
 			"isArchived",
 		])
+		.index("by_user_and_archived", ["userId", "isArchived"])
 		.index("by_folder_and_user", ["userId", "folderId"]),
 
 	messages: defineTable({

--- a/src/components/app-sidebar-chat-item-actions.tsx
+++ b/src/components/app-sidebar-chat-item-actions.tsx
@@ -1,6 +1,7 @@
 import { DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import { Suspense } from "react";
 import type { SidebarChatType } from "~/types";
+import AppSidebarChatItemArchive from "./app-sidebar-chat-item-archive";
 import AppSidebarChatItemDelete from "./app-sidebar-chat-item-delete";
 import AppSidebarChatItemFolder from "./app-sidebar-chat-item-folder";
 import AppSidebarChatItemPin from "./app-sidebar-chat-item-pin";
@@ -37,6 +38,7 @@ export default function AppSidebarChatItemActions(props: Props) {
 				<AppSidebarChatItemRename chat={props.chat} />
 				<AppSidebarChatItemPin chat={props.chat} />
 				<AppSidebarChatItemDelete chat={props.chat} />
+				<AppSidebarChatItemArchive chat={props.chat} />
 				<AppSidebarChatItemShare chat={props.chat} />
 				<Suspense fallback={<Skeleton className="h-3 w-3/4" />}>
 					<AppSidebarChatItemFolder chat={props.chat} />

--- a/src/components/app-sidebar-chat-item-archive.tsx
+++ b/src/components/app-sidebar-chat-item-archive.tsx
@@ -1,0 +1,39 @@
+import { useConvexMutation } from "@convex-dev/react-query";
+import { ArchiveBoxIcon } from "@phosphor-icons/react";
+import { useMutation } from "@tanstack/react-query";
+import { api } from "convex/_generated/api";
+import { toast } from "sonner";
+import type { SidebarChatType } from "~/types";
+import { DropdownMenuItem } from "./ui/dropdown-menu";
+
+type Props = {
+	chat: SidebarChatType;
+};
+
+export default function AppSidebarChatItemArchive(props: Props) {
+	const toggleChatArchiveMutation = useMutation({
+		mutationFn: useConvexMutation(api.chats.toggleChatArchive),
+		onSuccess: (wasArchived) => {
+			toast.success(wasArchived ? "Chat unarchived" : "Chat archived");
+		},
+		onError: () => {
+			toast.error("Could not archive chat", {
+				description: "Please try again later",
+			});
+		},
+	});
+
+	return (
+		<DropdownMenuItem
+			onClick={(e) => {
+				e.stopPropagation();
+				toggleChatArchiveMutation.mutate({
+					chatId: props.chat._id,
+				});
+			}}
+		>
+			<ArchiveBoxIcon />
+			<span className="leading-0">Archive</span>
+		</DropdownMenuItem>
+	);
+}

--- a/src/components/chat-history-archived-toggle.tsx
+++ b/src/components/chat-history-archived-toggle.tsx
@@ -1,0 +1,42 @@
+import {
+	chatHistorySelectionActions,
+	useChatHistorySelectionStore,
+} from "~/stores/chat-history-selection-store";
+import { Badge } from "./ui/badge";
+import { Label } from "./ui/label";
+import { Switch } from "./ui/switch";
+
+type Props = {
+	archivedChatCount: number;
+};
+
+export default function ChatHistoryArchivedToggle({
+	archivedChatCount,
+}: Props) {
+	const showArchived = useChatHistorySelectionStore((s) => s.showArchived);
+
+	return (
+		<div className="mt-6 flex items-center gap-3">
+			<Switch
+				checked={showArchived}
+				onCheckedChange={chatHistorySelectionActions.setShowArchived}
+				size="sm"
+				id="show-archived"
+			/>
+			<Label
+				className="cursor-pointer text-sm text-muted-foreground"
+				htmlFor="show-archived"
+			>
+				Archived chats
+			</Label>
+			{showArchived && archivedChatCount > 0 && (
+				<Badge
+					className="h-4 px-1 text-[0.625rem] font-medium"
+					variant="secondary"
+				>
+					{archivedChatCount}
+				</Badge>
+			)}
+		</div>
+	);
+}

--- a/src/components/chat-history-empty.tsx
+++ b/src/components/chat-history-empty.tsx
@@ -1,0 +1,18 @@
+import { ChatTeardropTextIcon } from "@phosphor-icons/react";
+
+type Props = {
+	title: string;
+	description: string;
+};
+
+export default function ChatHistoryEmpty({ title, description }: Props) {
+	return (
+		<div className="flex flex-col items-center justify-center rounded-lg border py-14 text-center">
+			<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+				<ChatTeardropTextIcon className="h-4 w-4 text-muted-foreground" />
+			</div>
+			<p className="text-sm font-medium text-foreground">{title}</p>
+			<p className="mt-1 text-xs text-muted-foreground">{description}</p>
+		</div>
+	);
+}

--- a/src/components/chat-history-grouped-list.tsx
+++ b/src/components/chat-history-grouped-list.tsx
@@ -1,0 +1,52 @@
+import { cn } from "~/lib/utils";
+import { useChatHistorySelectionStore } from "~/stores/chat-history-selection-store";
+import type { ChatHistoryItem } from "~/types";
+import ChatHistoryItemComponent from "./chat-history-item";
+import { ScrollArea } from "./ui/scroll-area";
+
+type Props = {
+	groups: { group: string; chats: ChatHistoryItem[] }[];
+	isArchived?: boolean;
+	onToggleArchive: (chatId: string) => void;
+	onDeleteSingle: (chatId: string) => void;
+	maxHeight?: string;
+};
+
+export default function ChatHistoryGroupedList({
+	groups,
+	isArchived = false,
+	onToggleArchive,
+	onDeleteSingle,
+	maxHeight = "h-[420px]",
+}: Props) {
+	const hasSelection = useChatHistorySelectionStore((s) =>
+		isArchived
+			? s.selectedArchivedChatIds.length > 0
+			: s.selectedChatIds.length > 0,
+	);
+
+	return (
+		<ScrollArea className={maxHeight}>
+			<div className={cn("space-y-5 p-3", hasSelection && "pb-14")}>
+				{groups.map(({ group, chats }) => (
+					<div className="space-y-1" key={group}>
+						<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
+							{group}
+						</h4>
+						<div className="space-y-0.5">
+							{chats.map((chat) => (
+								<ChatHistoryItemComponent
+									chat={chat}
+									isArchived={isArchived}
+									key={chat._id}
+									onDelete={onDeleteSingle}
+									onToggleArchive={onToggleArchive}
+								/>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</ScrollArea>
+	);
+}

--- a/src/components/chat-history-header.tsx
+++ b/src/components/chat-history-header.tsx
@@ -1,0 +1,29 @@
+import { Badge } from "./ui/badge";
+
+type Props = {
+	totalChatCount: number;
+	isLoading: boolean;
+};
+
+export default function ChatHistoryHeader({
+	totalChatCount,
+	isLoading,
+}: Props) {
+	return (
+		<div className="flex items-center justify-between">
+			<div className="flex items-center gap-2">
+				<h3 className="text-base font-semibold text-foreground">
+					Chat History
+				</h3>
+				{!isLoading && (
+					<Badge
+						className="h-5 px-1.5 text-[0.625rem] font-medium"
+						variant="secondary"
+					>
+						{totalChatCount}
+					</Badge>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/chat-history-item.tsx
+++ b/src/components/chat-history-item.tsx
@@ -1,0 +1,149 @@
+import {
+	ArchiveBoxIcon,
+	CheckIcon,
+	GitBranchIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
+import type { MouseEvent } from "react";
+import {
+	chatHistorySelectionActions,
+	useChatHistorySelectionStore,
+} from "~/stores/chat-history-selection-store";
+import type { ChatHistoryItem } from "~/types";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
+
+type Props = {
+	chat: ChatHistoryItem;
+	isArchived?: boolean;
+	onToggleArchive: (chatId: string) => void;
+	onDelete: (chatId: string) => void;
+};
+
+function formatDate(timestamp: number) {
+	return new Date(timestamp).toLocaleDateString("en-GB", {
+		day: "numeric",
+		month: "short",
+	});
+}
+
+export default function ChatHistoryItem({
+	chat,
+	isArchived = false,
+	onToggleArchive,
+	onDelete,
+}: Props) {
+	const isSelected = useChatHistorySelectionStore((s) =>
+		isArchived
+			? s.selectedArchivedChatIds.includes(chat._id)
+			: s.selectedChatIds.includes(chat._id),
+	);
+
+	const handleSelect = () => {
+		if (isArchived) {
+			chatHistorySelectionActions.toggleArchivedChat(chat._id);
+		} else {
+			chatHistorySelectionActions.toggleChat(chat._id);
+		}
+	};
+
+	const handleArchiveClick = (e: MouseEvent) => {
+		e.stopPropagation();
+		onToggleArchive(chat._id);
+	};
+
+	const handleDeleteClick = (e: MouseEvent) => {
+		e.stopPropagation();
+	};
+
+	return (
+		<div
+			className="group flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40"
+			onClick={handleSelect}
+		>
+			<button
+				className="pointer-events-none flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all"
+				type="button"
+				aria-label="Select chat"
+				aria-pressed={isSelected}
+			>
+				{isSelected ? (
+					<div className="flex h-full w-full items-center justify-center rounded-sm bg-primary">
+						<CheckIcon className="h-3 w-3 text-primary-foreground" />
+					</div>
+				) : (
+					<div className="h-full w-full rounded-sm bg-muted/20 group-hover:bg-muted/40" />
+				)}
+			</button>
+
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-1.5">
+					{chat.isBranched && (
+						<GitBranchIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+					)}
+					<span className="truncate text-sm font-medium text-foreground">
+						{chat.title}
+					</span>
+				</div>
+				<p className="text-xs text-muted-foreground">
+					{formatDate(chat._creationTime)}
+				</p>
+			</div>
+
+			<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+				<Button
+					className="h-6 w-6 shrink-0"
+					size="icon"
+					variant="ghost"
+					onClick={handleArchiveClick}
+					title={isArchived ? "Unarchive" : "Archive"}
+				>
+					<ArchiveBoxIcon className="h-3 w-3 text-muted-foreground" />
+				</Button>
+
+				<AlertDialog>
+					<AlertDialogTrigger
+						render={
+							<Button
+								className="h-6 w-6 shrink-0"
+								size="icon"
+								variant="ghost"
+								onClick={handleDeleteClick}
+							/>
+						}
+					>
+						<TrashIcon className="h-3 w-3 text-destructive" />
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete conversation</AlertDialogTitle>
+							<AlertDialogDescription>
+								Are you sure you want to delete "{chat.title}"? This action
+								cannot be undone.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction
+								variant="destructive"
+								onClick={() => onDelete(chat._id)}
+							>
+								Delete
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</div>
+		</div>
+	);
+}

--- a/src/components/chat-history-loading.tsx
+++ b/src/components/chat-history-loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "./ui/skeleton";
+
+export default function ChatHistoryLoading() {
+	return (
+		<div className="space-y-4">
+			{Array.from({ length: 4 }).map((_, i) => (
+				<div className="space-y-2" key={`skeleton-${i}`}>
+					<Skeleton className="h-3 w-20" />
+					<div className="space-y-1">
+						{Array.from({ length: 2 }).map((_, j) => (
+							<div
+								className="flex items-center gap-3 rounded-lg px-2 py-2"
+								key={`skeleton-item-${i}-${j}`}
+							>
+								<Skeleton className="h-4 w-4 rounded-sm" />
+								<div className="flex-1 space-y-1.5">
+									<Skeleton className="h-3.5 w-3/4" />
+									<Skeleton className="h-2.5 w-1/4" />
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/components/chat-history-manager.tsx
+++ b/src/components/chat-history-manager.tsx
@@ -1,46 +1,31 @@
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
-import {
-	ArchiveBoxIcon,
-	CheckIcon,
-	ChatTeardropTextIcon,
-	GitBranchIcon,
-	MagnifyingGlassIcon,
-	TrashIcon,
-	XIcon,
-} from "@phosphor-icons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "convex/_generated/api";
 import type { Id } from "convex/_generated/dataModel";
-import { useState } from "react";
 import { toast } from "sonner";
 import { groupChatsByDate } from "~/lib/group-chats-by-date";
 import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "./ui/alert-dialog";
-import { Badge } from "./ui/badge";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
-import { Label } from "./ui/label";
-import { ScrollArea } from "./ui/scroll-area";
-import { Skeleton } from "./ui/skeleton";
-import { Switch } from "./ui/switch";
+	chatHistorySelectionActions,
+	useChatHistorySelectionStore,
+} from "~/stores/chat-history-selection-store";
+import ChatHistoryArchivedToggle from "./chat-history-archived-toggle";
+import ChatHistoryEmpty from "./chat-history-empty";
+import ChatHistoryGroupedList from "./chat-history-grouped-list";
+import ChatHistoryHeader from "./chat-history-header";
+import ChatHistoryLoading from "./chat-history-loading";
+import ChatHistorySearch from "./chat-history-search";
+import ChatHistorySelectionBar from "./chat-history-selection-bar";
 import { TabsContent } from "./ui/tabs";
 
 export default function ChatHistoryManager() {
-	const [selectedChats, setSelectedChats] = useState<Set<string>>(new Set());
-	const [selectedArchivedChats, setSelectedArchivedChats] = useState<
-		Set<string>
-	>(new Set());
-	const [searchQuery, setSearchQuery] = useState("");
-	const [showArchived, setShowArchived] = useState(false);
+	const selectedChatIds = useChatHistorySelectionStore(
+		(s) => s.selectedChatIds,
+	);
+	const selectedArchivedChatIds = useChatHistorySelectionStore(
+		(s) => s.selectedArchivedChatIds,
+	);
+	const showArchived = useChatHistorySelectionStore((s) => s.showArchived);
+	const searchQuery = useChatHistorySelectionStore((s) => s.searchQuery);
 
 	const { data: chats = [], isLoading } = useQuery(
 		convexQuery(api.chats.getChats, {}),
@@ -54,7 +39,7 @@ export default function ChatHistoryManager() {
 		mutationFn: useConvexMutation(api.chats.deleteChat),
 		onSuccess: () => {
 			toast.success("Chat deleted");
-			setSelectedChats(new Set());
+			chatHistorySelectionActions.clearChatSelection();
 		},
 		onError: () => {
 			toast.error("Failed to delete chats", {
@@ -79,7 +64,7 @@ export default function ChatHistoryManager() {
 		mutationFn: useConvexMutation(api.chats.archiveAll),
 		onSuccess: () => {
 			toast.success("Chats archived");
-			setSelectedChats(new Set());
+			chatHistorySelectionActions.clearChatSelection();
 		},
 		onError: () => {
 			toast.error("Failed to archive chats", {
@@ -92,7 +77,7 @@ export default function ChatHistoryManager() {
 		mutationFn: useConvexMutation(api.chats.unarchiveAll),
 		onSuccess: () => {
 			toast.success("Chats unarchived");
-			setSelectedArchivedChats(new Set());
+			chatHistorySelectionActions.clearArchivedChatSelection();
 		},
 		onError: () => {
 			toast.error("Failed to unarchive chats", {
@@ -110,499 +95,142 @@ export default function ChatHistoryManager() {
 	const groupedChats = groupChatsByDate(filteredChats);
 	const groupedArchived = groupChatsByDate(archivedChats);
 
-	const handleSelectChat = (chatId: string) => {
-		const newSelected = new Set(selectedChats);
-		if (newSelected.has(chatId)) {
-			newSelected.delete(chatId);
-		} else {
-			newSelected.add(chatId);
-		}
-		setSelectedChats(newSelected);
+	const isAllSelected =
+		filteredChats.length > 0 && selectedChatIds.length === filteredChats.length;
+
+	const isAllArchivedSelected =
+		selectedArchivedChatIds.length === archivedChats.length;
+
+	const hasSearchQuery = searchQuery.trim().length > 0;
+
+	const handleToggleArchive = (chatId: string) => {
+		toggleArchiveMutation.mutate({ chatId: chatId as Id<"chats"> });
+	};
+
+	const handleDeleteSingle = (chatId: string) => {
+		deleteChatMutation.mutate({ chatId: chatId as Id<"chats"> });
 	};
 
 	const handleSelectAll = () => {
-		if (selectedChats.size === filteredChats.length) {
-			setSelectedChats(new Set());
+		if (selectedChatIds.length === filteredChats.length) {
+			chatHistorySelectionActions.clearChatSelection();
 		} else {
-			setSelectedChats(new Set(filteredChats.map((chat) => chat._id)));
+			chatHistorySelectionActions.selectAllChats(
+				filteredChats.map((chat) => chat._id),
+			);
 		}
 	};
 
+	const handleSelectAllArchived = () => {
+		if (selectedArchivedChatIds.length === archivedChats.length) {
+			chatHistorySelectionActions.clearArchivedChatSelection();
+		} else {
+			chatHistorySelectionActions.selectAllArchivedChats(
+				archivedChats.map((chat) => chat._id),
+			);
+		}
+	};
+
+	const handleArchiveSelected = () => {
+		if (selectedChatIds.length === 0) return;
+		archiveAllMutation.mutate({
+			chatIds: selectedChatIds as Id<"chats">[],
+		});
+	};
+
 	const handleDeleteSelected = () => {
-		if (selectedChats.size === 0) return;
-		for (const chatId of selectedChats) {
+		if (selectedChatIds.length === 0) return;
+		for (const chatId of selectedChatIds) {
 			const chat = chats.find((c) => c._id === chatId);
 			if (chat) deleteChatMutation.mutate({ chatId: chat._id });
 		}
 	};
 
-	const handleArchiveSelected = () => {
-		if (selectedChats.size === 0) return;
-		archiveAllMutation.mutate({
-			chatIds: [...selectedChats] as Id<"chats">[],
+	const handleUnarchiveSelected = () => {
+		if (selectedArchivedChatIds.length === 0) return;
+		unarchiveAllMutation.mutate({
+			chatIds: selectedArchivedChatIds as Id<"chats">[],
 		});
-	};
-
-	const handleDeleteSingle = (chat: (typeof chats)[number]) => {
-		deleteChatMutation.mutate({ chatId: chat._id });
-	};
-
-	const handleToggleArchive = (
-		chat: (typeof chats)[number],
-		e: React.MouseEvent,
-	) => {
-		e.stopPropagation();
-		toggleArchiveMutation.mutate({ chatId: chat._id });
-	};
-
-	const handleSelectArchivedChat = (chatId: string) => {
-		const newSelected = new Set(selectedArchivedChats);
-		if (newSelected.has(chatId)) {
-			newSelected.delete(chatId);
-		} else {
-			newSelected.add(chatId);
-		}
-		setSelectedArchivedChats(newSelected);
-	};
-
-	const handleSelectAllArchived = () => {
-		if (selectedArchivedChats.size === archivedChats.length) {
-			setSelectedArchivedChats(new Set());
-		} else {
-			setSelectedArchivedChats(new Set(archivedChats.map((chat) => chat._id)));
-		}
 	};
 
 	const handleDeleteSelectedArchived = () => {
-		if (selectedArchivedChats.size === 0) return;
-		for (const chatId of selectedArchivedChats) {
+		if (selectedArchivedChatIds.length === 0) return;
+		for (const chatId of selectedArchivedChatIds) {
 			const chat = archivedChats.find((c) => c._id === chatId);
 			if (chat) deleteChatMutation.mutate({ chatId: chat._id });
 		}
-		setSelectedArchivedChats(new Set());
-	};
-
-	const handleUnarchiveSelected = () => {
-		if (selectedArchivedChats.size === 0) return;
-		unarchiveAllMutation.mutate({
-			chatIds: [...selectedArchivedChats] as Id<"chats">[],
-		});
-	};
-
-	const formatDate = (timestamp: number) =>
-		new Date(timestamp).toLocaleDateString("en-GB", {
-			day: "numeric",
-			month: "short",
-		});
-
-	const isAllSelected =
-		filteredChats.length > 0 && selectedChats.size === filteredChats.length;
-
-	const renderChatRow = (
-		chat: (typeof chats)[number],
-		{
-			isArchived = false,
-			selectionSet,
-			onSelect,
-		}: {
-			isArchived?: boolean;
-			selectionSet: Set<string>;
-			onSelect: (chatId: string) => void;
-		},
-	) => {
-		const isSelected = selectionSet.has(chat._id);
-		return (
-			<div
-				className="group flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40"
-				key={chat._id}
-				onClick={() => onSelect(chat._id)}
-			>
-				{/* Checkbox */}
-				<button
-					className="pointer-events-none flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all"
-					type="button"
-					aria-label="Select chat"
-					aria-pressed={isSelected}
-				>
-					{isSelected ? (
-						<div className="flex h-full w-full items-center justify-center rounded-sm bg-primary">
-							<CheckIcon className="h-3 w-3 text-primary-foreground" />
-						</div>
-					) : (
-						<div className="h-full w-full rounded-sm bg-muted/20 group-hover:bg-muted/40" />
-					)}
-				</button>
-
-				{/* Info */}
-				<div className="min-w-0 flex-1">
-					<div className="flex items-center gap-1.5">
-						{chat.isBranched && (
-							<GitBranchIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
-						)}
-						<span className="truncate text-sm font-medium text-foreground">
-							{chat.title}
-						</span>
-					</div>
-					<p className="text-xs text-muted-foreground">
-						{formatDate(chat._creationTime)}
-					</p>
-				</div>
-
-				{/* Hover actions */}
-				<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-					<Button
-						className="h-6 w-6 shrink-0"
-						size="icon"
-						variant="ghost"
-						onClick={(e) => handleToggleArchive(chat, e)}
-						title={isArchived ? "Unarchive" : "Archive"}
-					>
-						<ArchiveBoxIcon className="h-3 w-3 text-muted-foreground" />
-					</Button>
-
-					<AlertDialog>
-						<AlertDialogTrigger
-							render={
-								<Button
-									className="h-6 w-6 shrink-0"
-									size="icon"
-									variant="ghost"
-									onClick={(e) => e.stopPropagation()}
-								/>
-							}
-						>
-							<TrashIcon className="h-3 w-3 text-destructive" />
-						</AlertDialogTrigger>
-						<AlertDialogContent>
-							<AlertDialogHeader>
-								<AlertDialogTitle>Delete conversation</AlertDialogTitle>
-								<AlertDialogDescription>
-									Are you sure you want to delete "{chat.title}"? This action
-									cannot be undone.
-								</AlertDialogDescription>
-							</AlertDialogHeader>
-							<AlertDialogFooter>
-								<AlertDialogCancel>Cancel</AlertDialogCancel>
-								<AlertDialogAction
-									variant="destructive"
-									onClick={() => handleDeleteSingle(chat)}
-								>
-									Delete
-								</AlertDialogAction>
-							</AlertDialogFooter>
-						</AlertDialogContent>
-					</AlertDialog>
-				</div>
-			</div>
-		);
+		chatHistorySelectionActions.clearArchivedChatSelection();
 	};
 
 	return (
 		<TabsContent className="space-y-5" value="chatHistory">
-			{/* Header */}
-			<div className="flex items-center justify-between">
-				<div className="flex items-center gap-2">
-					<h3 className="text-base font-semibold text-foreground">
-						Chat History
-					</h3>
-					{!isLoading && (
-						<Badge
-							className="h-5 px-1.5 text-[0.625rem] font-medium"
-							variant="secondary"
-						>
-							{chats.length}
-						</Badge>
-					)}
-				</div>
-			</div>
+			<ChatHistoryHeader totalChatCount={chats.length} isLoading={isLoading} />
 
-			{/* Search */}
-			{chats.length > 0 && (
-				<div className="relative">
-					<MagnifyingGlassIcon className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-					<Input
-						className="h-8 rounded-lg border bg-transparent py-0 pl-8 text-xs"
-						placeholder="Search conversations..."
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-					/>
-				</div>
-			)}
+			{chats.length > 0 && <ChatHistorySearch />}
 
-			{/* Content */}
-			{isLoading ? (
-				<div className="space-y-4">
-					{Array.from({ length: 4 }).map((_, i) => (
-						<div className="space-y-2" key={`skeleton-${i}`}>
-							<Skeleton className="h-3 w-20" />
-							<div className="space-y-1">
-								{Array.from({ length: 2 }).map((_, j) => (
-									<div
-										className="flex items-center gap-3 rounded-lg px-2 py-2"
-										key={`skeleton-item-${i}-${j}`}
-									>
-										<Skeleton className="h-4 w-4 rounded-sm" />
-										<div className="flex-1 space-y-1.5">
-											<Skeleton className="h-3.5 w-3/4" />
-											<Skeleton className="h-2.5 w-1/4" />
-										</div>
-									</div>
-								))}
-							</div>
-						</div>
-					))}
-				</div>
-			) : filteredChats.length === 0 ? (
-				<div className="flex flex-col items-center justify-center rounded-lg border py-14 text-center">
-					<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-						<ChatTeardropTextIcon className="h-4 w-4 text-muted-foreground" />
-					</div>
-					<p className="text-sm font-medium text-foreground">
-						{searchQuery ? "No matches found" : "No conversations yet"}
-					</p>
-					<p className="mt-1 text-xs text-muted-foreground">
-						{searchQuery
+			{isLoading && <ChatHistoryLoading />}
+
+			{!isLoading && filteredChats.length === 0 && (
+				<ChatHistoryEmpty
+					description={
+						hasSearchQuery
 							? "Try a different search term"
-							: "Your chat history will appear here"}
-					</p>
-				</div>
-			) : (
-				<div className="relative rounded-lg border">
-					<ScrollArea className="h-[420px]">
-						<div
-							className={`space-y-5 p-3 ${selectedChats.size > 0 ? "pb-14" : ""}`}
-						>
-							{groupedChats.map(({ group, chats: groupChats }) => (
-								<div className="space-y-1" key={group}>
-									<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
-										{group}
-									</h4>
-									<div className="space-y-0.5">
-										{groupChats.map((chat) =>
-											renderChatRow(chat, {
-												selectionSet: selectedChats,
-												onSelect: handleSelectChat,
-											}),
-										)}
-									</div>
-								</div>
-							))}
-						</div>
-					</ScrollArea>
+							: "Your chat history will appear here"
+					}
+					title={hasSearchQuery ? "No matches found" : "No conversations yet"}
+				/>
+			)}
 
-					{/* Floating selection bar */}
-					{selectedChats.size > 0 && (
-						<div className="absolute right-0 bottom-0 left-0 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
-							<div className="flex items-center gap-2">
-								<Button
-									className="h-7 px-2 text-xs"
-									size="sm"
-									variant="ghost"
-									onClick={handleSelectAll}
-								>
-									{isAllSelected ? "Deselect all" : "Select all"}
-								</Button>
-								<Button
-									className="h-7 px-2 text-xs"
-									size="sm"
-									variant="ghost"
-									onClick={() => setSelectedChats(new Set())}
-								>
-									<XIcon className="mr-1 h-3 w-3" />
-									Clear
-								</Button>
-							</div>
-							<div className="flex items-center gap-2">
-								<Button
-									className="h-7 gap-1 px-2 text-xs"
-									size="sm"
-									variant="secondary"
-									onClick={handleArchiveSelected}
-								>
-									<ArchiveBoxIcon className="h-3 w-3" />
-									Archive {selectedChats.size}
-								</Button>
-								<AlertDialog>
-									<AlertDialogTrigger
-										render={
-											<Button
-												className="h-7 px-2 text-xs"
-												size="sm"
-												variant="destructive"
-											/>
-										}
-									>
-										<TrashIcon className="mr-1 h-3 w-3" />
-										Delete {selectedChats.size}
-									</AlertDialogTrigger>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>
-												Delete {selectedChats.size} conversation
-												{selectedChats.size > 1 ? "s" : ""}
-											</AlertDialogTitle>
-											<AlertDialogDescription>
-												Are you sure you want to delete these conversations?
-												This action cannot be undone.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel>Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												variant="destructive"
-												disabled={deleteChatMutation.isPending}
-												onClick={handleDeleteSelected}
-											>
-												{deleteChatMutation.isPending
-													? "Deleting..."
-													: "Delete"}
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
-							</div>
-						</div>
+			{!isLoading && filteredChats.length > 0 && (
+				<div className="relative rounded-lg border">
+					<ChatHistoryGroupedList
+						groups={groupedChats}
+						onDeleteSingle={handleDeleteSingle}
+						onToggleArchive={handleToggleArchive}
+					/>
+					{selectedChatIds.length > 0 && (
+						<ChatHistorySelectionBar
+							isAllSelected={isAllSelected}
+							isArchived={false}
+							isDeletePending={deleteChatMutation.isPending}
+							onArchiveAction={handleArchiveSelected}
+							onDeleteAction={handleDeleteSelected}
+							onSelectAll={handleSelectAll}
+						/>
 					)}
 				</div>
 			)}
 
-			{/* Archived chats toggle */}
-			<div className="mt-6 flex items-center gap-3">
-				<Switch
-					checked={showArchived}
-					onCheckedChange={setShowArchived}
-					size="sm"
-					id="show-archived"
+			<ChatHistoryArchivedToggle archivedChatCount={archivedChats.length} />
+
+			{showArchived && archivedChats.length > 0 && (
+				<div className="relative rounded-lg border">
+					<ChatHistoryGroupedList
+						groups={groupedArchived}
+						isArchived
+						maxHeight="h-[300px]"
+						onDeleteSingle={handleDeleteSingle}
+						onToggleArchive={handleToggleArchive}
+					/>
+					{selectedArchivedChatIds.length > 0 && (
+						<ChatHistorySelectionBar
+							isAllSelected={isAllArchivedSelected}
+							isArchived
+							isDeletePending={deleteChatMutation.isPending}
+							onArchiveAction={handleUnarchiveSelected}
+							onDeleteAction={handleDeleteSelectedArchived}
+							onSelectAll={handleSelectAllArchived}
+						/>
+					)}
+				</div>
+			)}
+
+			{showArchived && archivedChats.length === 0 && (
+				<ChatHistoryEmpty
+					description="Archive a conversation to see it here"
+					title="No archived chats"
 				/>
-				<Label
-					className="cursor-pointer text-sm text-muted-foreground"
-					htmlFor="show-archived"
-				>
-					Archived chats
-				</Label>
-				{showArchived && archivedChats.length > 0 && (
-					<Badge
-						className="h-4 px-1 text-[0.625rem] font-medium"
-						variant="secondary"
-					>
-						{archivedChats.length}
-					</Badge>
-				)}
-			</div>
-
-			{/* Archived chats list */}
-			{showArchived &&
-				(archivedChats.length > 0 ? (
-					<div className="relative rounded-lg border">
-						<ScrollArea className="max-h-[300px]">
-							<div
-								className={`space-y-5 p-3 ${selectedArchivedChats.size > 0 ? "pb-14" : ""}`}
-							>
-								{groupedArchived.map(({ group, chats: groupChats }) => (
-									<div className="space-y-1" key={`archived-${group}`}>
-										<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
-											{group}
-										</h4>
-										<div className="space-y-0.5">
-											{groupChats.map((chat) =>
-												renderChatRow(chat, {
-													isArchived: true,
-													selectionSet: selectedArchivedChats,
-													onSelect: handleSelectArchivedChat,
-												}),
-											)}
-										</div>
-									</div>
-								))}
-							</div>
-						</ScrollArea>
-
-						{/* Floating selection bar for archived */}
-						{selectedArchivedChats.size > 0 && (
-							<div className="absolute right-0 bottom-0 left-0 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
-								<div className="flex items-center gap-2">
-									<Button
-										className="h-7 px-2 text-xs"
-										size="sm"
-										variant="ghost"
-										onClick={handleSelectAllArchived}
-									>
-										{selectedArchivedChats.size === archivedChats.length
-											? "Deselect all"
-											: "Select all"}
-									</Button>
-									<Button
-										className="h-7 px-2 text-xs"
-										size="sm"
-										variant="ghost"
-										onClick={() => setSelectedArchivedChats(new Set())}
-									>
-										<XIcon className="mr-1 h-3 w-3" />
-										Clear
-									</Button>
-								</div>
-								<div className="flex items-center gap-2">
-									<Button
-										className="h-7 px-2 text-xs"
-										size="sm"
-										variant="secondary"
-										onClick={handleUnarchiveSelected}
-									>
-										<ArchiveBoxIcon className="mr-1 h-3 w-3" />
-										Unarchive {selectedArchivedChats.size}
-									</Button>
-									<AlertDialog>
-										<AlertDialogTrigger
-											render={
-												<Button
-													className="h-7 px-2 text-xs"
-													size="sm"
-													variant="destructive"
-												/>
-											}
-										>
-											<TrashIcon className="mr-1 h-3 w-3" />
-											Delete {selectedArchivedChats.size}
-										</AlertDialogTrigger>
-										<AlertDialogContent>
-											<AlertDialogHeader>
-												<AlertDialogTitle>
-													Delete {selectedArchivedChats.size} conversation
-													{selectedArchivedChats.size > 1 ? "s" : ""}
-												</AlertDialogTitle>
-												<AlertDialogDescription>
-													Are you sure you want to delete these conversations?
-													This action cannot be undone.
-												</AlertDialogDescription>
-											</AlertDialogHeader>
-											<AlertDialogFooter>
-												<AlertDialogCancel>Cancel</AlertDialogCancel>
-												<AlertDialogAction
-													variant="destructive"
-													disabled={deleteChatMutation.isPending}
-													onClick={handleDeleteSelectedArchived}
-												>
-													{deleteChatMutation.isPending
-														? "Deleting..."
-														: "Delete"}
-												</AlertDialogAction>
-											</AlertDialogFooter>
-										</AlertDialogContent>
-									</AlertDialog>
-								</div>
-							</div>
-						)}
-					</div>
-				) : (
-					<div className="flex flex-col items-center justify-center rounded-lg border py-10 text-center">
-						<p className="text-sm font-medium text-foreground">
-							No archived chats
-						</p>
-						<p className="mt-1 text-xs text-muted-foreground">
-							Archive a conversation to see it here
-						</p>
-					</div>
-				))}
+			)}
 		</TabsContent>
 	);
 }

--- a/src/components/chat-history-manager.tsx
+++ b/src/components/chat-history-manager.tsx
@@ -1,5 +1,6 @@
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import {
+	ArchiveBoxIcon,
 	CheckIcon,
 	ChatTeardropTextIcon,
 	GitBranchIcon,
@@ -9,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "convex/_generated/api";
+import type { Id } from "convex/_generated/dataModel";
 import { useState } from "react";
 import { toast } from "sonner";
 import { groupChatsByDate } from "~/lib/group-chats-by-date";
@@ -26,16 +28,26 @@ import {
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { Label } from "./ui/label";
 import { ScrollArea } from "./ui/scroll-area";
 import { Skeleton } from "./ui/skeleton";
+import { Switch } from "./ui/switch";
 import { TabsContent } from "./ui/tabs";
 
 export default function ChatHistoryManager() {
 	const [selectedChats, setSelectedChats] = useState<Set<string>>(new Set());
+	const [selectedArchivedChats, setSelectedArchivedChats] = useState<
+		Set<string>
+	>(new Set());
 	const [searchQuery, setSearchQuery] = useState("");
+	const [showArchived, setShowArchived] = useState(false);
 
 	const { data: chats = [], isLoading } = useQuery(
 		convexQuery(api.chats.getChats, {}),
+	);
+
+	const { data: archivedChats = [] } = useQuery(
+		convexQuery(api.chats.getArchivedChats, {}),
 	);
 
 	const deleteChatMutation = useMutation({
@@ -51,6 +63,44 @@ export default function ChatHistoryManager() {
 		},
 	});
 
+	const toggleArchiveMutation = useMutation({
+		mutationFn: useConvexMutation(api.chats.toggleChatArchive),
+		onSuccess: (wasArchived) => {
+			toast.success(wasArchived ? "Chat unarchived" : "Chat archived");
+		},
+		onError: () => {
+			toast.error("Failed to archive chat", {
+				description: "Please try again later",
+			});
+		},
+	});
+
+	const archiveAllMutation = useMutation({
+		mutationFn: useConvexMutation(api.chats.archiveAll),
+		onSuccess: () => {
+			toast.success("Chats archived");
+			setSelectedChats(new Set());
+		},
+		onError: () => {
+			toast.error("Failed to archive chats", {
+				description: "Please try again later",
+			});
+		},
+	});
+
+	const unarchiveAllMutation = useMutation({
+		mutationFn: useConvexMutation(api.chats.unarchiveAll),
+		onSuccess: () => {
+			toast.success("Chats unarchived");
+			setSelectedArchivedChats(new Set());
+		},
+		onError: () => {
+			toast.error("Failed to unarchive chats", {
+				description: "Please try again later",
+			});
+		},
+	});
+
 	const filteredChats = !searchQuery.trim()
 		? chats
 		: chats.filter((chat) =>
@@ -58,6 +108,7 @@ export default function ChatHistoryManager() {
 			);
 
 	const groupedChats = groupChatsByDate(filteredChats);
+	const groupedArchived = groupChatsByDate(archivedChats);
 
 	const handleSelectChat = (chatId: string) => {
 		const newSelected = new Set(selectedChats);
@@ -85,8 +136,57 @@ export default function ChatHistoryManager() {
 		}
 	};
 
+	const handleArchiveSelected = () => {
+		if (selectedChats.size === 0) return;
+		archiveAllMutation.mutate({
+			chatIds: [...selectedChats] as Id<"chats">[],
+		});
+	};
+
 	const handleDeleteSingle = (chat: (typeof chats)[number]) => {
 		deleteChatMutation.mutate({ chatId: chat._id });
+	};
+
+	const handleToggleArchive = (
+		chat: (typeof chats)[number],
+		e: React.MouseEvent,
+	) => {
+		e.stopPropagation();
+		toggleArchiveMutation.mutate({ chatId: chat._id });
+	};
+
+	const handleSelectArchivedChat = (chatId: string) => {
+		const newSelected = new Set(selectedArchivedChats);
+		if (newSelected.has(chatId)) {
+			newSelected.delete(chatId);
+		} else {
+			newSelected.add(chatId);
+		}
+		setSelectedArchivedChats(newSelected);
+	};
+
+	const handleSelectAllArchived = () => {
+		if (selectedArchivedChats.size === archivedChats.length) {
+			setSelectedArchivedChats(new Set());
+		} else {
+			setSelectedArchivedChats(new Set(archivedChats.map((chat) => chat._id)));
+		}
+	};
+
+	const handleDeleteSelectedArchived = () => {
+		if (selectedArchivedChats.size === 0) return;
+		for (const chatId of selectedArchivedChats) {
+			const chat = archivedChats.find((c) => c._id === chatId);
+			if (chat) deleteChatMutation.mutate({ chatId: chat._id });
+		}
+		setSelectedArchivedChats(new Set());
+	};
+
+	const handleUnarchiveSelected = () => {
+		if (selectedArchivedChats.size === 0) return;
+		unarchiveAllMutation.mutate({
+			chatIds: [...selectedArchivedChats] as Id<"chats">[],
+		});
 	};
 
 	const formatDate = (timestamp: number) =>
@@ -97,6 +197,105 @@ export default function ChatHistoryManager() {
 
 	const isAllSelected =
 		filteredChats.length > 0 && selectedChats.size === filteredChats.length;
+
+	const renderChatRow = (
+		chat: (typeof chats)[number],
+		{
+			isArchived = false,
+			selectionSet,
+			onSelect,
+		}: {
+			isArchived?: boolean;
+			selectionSet: Set<string>;
+			onSelect: (chatId: string) => void;
+		},
+	) => {
+		const isSelected = selectionSet.has(chat._id);
+		return (
+			<div
+				className="group flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40"
+				key={chat._id}
+				onClick={() => onSelect(chat._id)}
+			>
+				{/* Checkbox */}
+				<button
+					className="pointer-events-none flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all"
+					type="button"
+					aria-label="Select chat"
+					aria-pressed={isSelected}
+				>
+					{isSelected ? (
+						<div className="flex h-full w-full items-center justify-center rounded-sm bg-primary">
+							<CheckIcon className="h-3 w-3 text-primary-foreground" />
+						</div>
+					) : (
+						<div className="h-full w-full rounded-sm bg-muted/20 group-hover:bg-muted/40" />
+					)}
+				</button>
+
+				{/* Info */}
+				<div className="min-w-0 flex-1">
+					<div className="flex items-center gap-1.5">
+						{chat.isBranched && (
+							<GitBranchIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+						)}
+						<span className="truncate text-sm font-medium text-foreground">
+							{chat.title}
+						</span>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						{formatDate(chat._creationTime)}
+					</p>
+				</div>
+
+				{/* Hover actions */}
+				<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+					<Button
+						className="h-6 w-6 shrink-0"
+						size="icon"
+						variant="ghost"
+						onClick={(e) => handleToggleArchive(chat, e)}
+						title={isArchived ? "Unarchive" : "Archive"}
+					>
+						<ArchiveBoxIcon className="h-3 w-3 text-muted-foreground" />
+					</Button>
+
+					<AlertDialog>
+						<AlertDialogTrigger
+							render={
+								<Button
+									className="h-6 w-6 shrink-0"
+									size="icon"
+									variant="ghost"
+									onClick={(e) => e.stopPropagation()}
+								/>
+							}
+						>
+							<TrashIcon className="h-3 w-3 text-destructive" />
+						</AlertDialogTrigger>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>Delete conversation</AlertDialogTitle>
+								<AlertDialogDescription>
+									Are you sure you want to delete "{chat.title}"? This action
+									cannot be undone.
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel>Cancel</AlertDialogCancel>
+								<AlertDialogAction
+									variant="destructive"
+									onClick={() => handleDeleteSingle(chat)}
+								>
+									Delete
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<TabsContent className="space-y-5" value="chatHistory">
@@ -179,83 +378,12 @@ export default function ChatHistoryManager() {
 										{group}
 									</h4>
 									<div className="space-y-0.5">
-										{groupChats.map((chat) => {
-											const isSelected = selectedChats.has(chat._id);
-											return (
-												<div
-													className="group flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40"
-													key={chat._id}
-													onClick={() => handleSelectChat(chat._id)}
-												>
-													{/* Checkbox */}
-													<button
-														className="pointer-events-none flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all"
-														type="button"
-														aria-label="Select chat"
-														aria-pressed={isSelected}
-													>
-														{isSelected ? (
-															<div className="flex h-full w-full items-center justify-center rounded-sm bg-primary">
-																<CheckIcon className="h-3 w-3 text-primary-foreground" />
-															</div>
-														) : (
-															<div className="h-full w-full rounded-sm bg-muted/20 group-hover:bg-muted/40" />
-														)}
-													</button>
-
-													{/* Info */}
-													<div className="min-w-0 flex-1">
-														<div className="flex items-center gap-1.5">
-															{chat.isBranched && (
-																<GitBranchIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
-															)}
-															<span className="truncate text-sm font-medium text-foreground">
-																{chat.title}
-															</span>
-														</div>
-														<p className="text-xs text-muted-foreground">
-															{formatDate(chat._creationTime)}
-														</p>
-													</div>
-
-													{/* Hover delete */}
-													<AlertDialog>
-														<AlertDialogTrigger
-															render={
-																<Button
-																	className="h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-																	size="icon"
-																	variant="ghost"
-																	onClick={(e) => e.stopPropagation()}
-																/>
-															}
-														>
-															<TrashIcon className="h-3 w-3 text-destructive" />
-														</AlertDialogTrigger>
-														<AlertDialogContent>
-															<AlertDialogHeader>
-																<AlertDialogTitle>
-																	Delete conversation
-																</AlertDialogTitle>
-																<AlertDialogDescription>
-																	Are you sure you want to delete "{chat.title}
-																	"? This action cannot be undone.
-																</AlertDialogDescription>
-															</AlertDialogHeader>
-															<AlertDialogFooter>
-																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction
-																	variant="destructive"
-																	onClick={() => handleDeleteSingle(chat)}
-																>
-																	Delete
-																</AlertDialogAction>
-															</AlertDialogFooter>
-														</AlertDialogContent>
-													</AlertDialog>
-												</div>
-											);
-										})}
+										{groupChats.map((chat) =>
+											renderChatRow(chat, {
+												selectionSet: selectedChats,
+												onSelect: handleSelectChat,
+											}),
+										)}
 									</div>
 								</div>
 							))}
@@ -284,42 +412,185 @@ export default function ChatHistoryManager() {
 									Clear
 								</Button>
 							</div>
-							<AlertDialog>
-								<AlertDialogTrigger
-									render={
-										<Button
-											className="h-7 px-2 text-xs"
-											size="sm"
-											variant="destructive"
-										/>
-									}
+							<div className="flex items-center gap-2">
+								<Button
+									className="h-7 gap-1 px-2 text-xs"
+									size="sm"
+									variant="secondary"
+									onClick={handleArchiveSelected}
 								>
-									<TrashIcon className="mr-1 h-3 w-3" />
-									Delete {selectedChats.size}
-								</AlertDialogTrigger>
-								<AlertDialogContent>
-									<AlertDialogHeader>
-										<AlertDialogTitle>
-											Delete {selectedChats.size} conversation
-											{selectedChats.size > 1 ? "s" : ""}
-										</AlertDialogTitle>
-										<AlertDialogDescription>
-											Are you sure you want to delete these conversations? This
-											action cannot be undone.
-										</AlertDialogDescription>
-									</AlertDialogHeader>
-									<AlertDialogFooter>
-										<AlertDialogCancel>Cancel</AlertDialogCancel>
-										<AlertDialogAction
-											variant="destructive"
-											disabled={deleteChatMutation.isPending}
-											onClick={handleDeleteSelected}
-										>
-											{deleteChatMutation.isPending ? "Deleting..." : "Delete"}
-										</AlertDialogAction>
-									</AlertDialogFooter>
-								</AlertDialogContent>
-							</AlertDialog>
+									<ArchiveBoxIcon className="h-3 w-3" />
+									Archive {selectedChats.size}
+								</Button>
+								<AlertDialog>
+									<AlertDialogTrigger
+										render={
+											<Button
+												className="h-7 px-2 text-xs"
+												size="sm"
+												variant="destructive"
+											/>
+										}
+									>
+										<TrashIcon className="mr-1 h-3 w-3" />
+										Delete {selectedChats.size}
+									</AlertDialogTrigger>
+									<AlertDialogContent>
+										<AlertDialogHeader>
+											<AlertDialogTitle>
+												Delete {selectedChats.size} conversation
+												{selectedChats.size > 1 ? "s" : ""}
+											</AlertDialogTitle>
+											<AlertDialogDescription>
+												Are you sure you want to delete these conversations?
+												This action cannot be undone.
+											</AlertDialogDescription>
+										</AlertDialogHeader>
+										<AlertDialogFooter>
+											<AlertDialogCancel>Cancel</AlertDialogCancel>
+											<AlertDialogAction
+												variant="destructive"
+												disabled={deleteChatMutation.isPending}
+												onClick={handleDeleteSelected}
+											>
+												{deleteChatMutation.isPending
+													? "Deleting..."
+													: "Delete"}
+											</AlertDialogAction>
+										</AlertDialogFooter>
+									</AlertDialogContent>
+								</AlertDialog>
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Archived chats toggle */}
+			{archivedChats.length > 0 && (
+				<div className="mt-6 flex items-center gap-3">
+					<Switch
+						checked={showArchived}
+						onCheckedChange={setShowArchived}
+						size="sm"
+						id="show-archived"
+					/>
+					<Label
+						className="cursor-pointer text-sm text-muted-foreground"
+						htmlFor="show-archived"
+					>
+						Archived chats
+					</Label>
+					{showArchived && (
+						<Badge
+							className="h-4 px-1 text-[0.625rem] font-medium"
+							variant="secondary"
+						>
+							{archivedChats.length}
+						</Badge>
+					)}
+				</div>
+			)}
+
+			{/* Archived chats list */}
+			{showArchived && archivedChats.length > 0 && (
+				<div className="relative rounded-lg border">
+					<ScrollArea className="max-h-[300px]">
+						<div
+							className={`space-y-5 p-3 ${selectedArchivedChats.size > 0 ? "pb-14" : ""}`}
+						>
+							{groupedArchived.map(({ group, chats: groupChats }) => (
+								<div className="space-y-1" key={`archived-${group}`}>
+									<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
+										{group}
+									</h4>
+									<div className="space-y-0.5">
+										{groupChats.map((chat) =>
+											renderChatRow(chat, {
+												isArchived: true,
+												selectionSet: selectedArchivedChats,
+												onSelect: handleSelectArchivedChat,
+											}),
+										)}
+									</div>
+								</div>
+							))}
+						</div>
+					</ScrollArea>
+
+					{/* Floating selection bar for archived */}
+					{selectedArchivedChats.size > 0 && (
+						<div className="absolute right-0 bottom-0 left-0 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
+							<div className="flex items-center gap-2">
+								<Button
+									className="h-7 px-2 text-xs"
+									size="sm"
+									variant="ghost"
+									onClick={handleSelectAllArchived}
+								>
+									{selectedArchivedChats.size === archivedChats.length
+										? "Deselect all"
+										: "Select all"}
+								</Button>
+								<Button
+									className="h-7 px-2 text-xs"
+									size="sm"
+									variant="ghost"
+									onClick={() => setSelectedArchivedChats(new Set())}
+								>
+									<XIcon className="mr-1 h-3 w-3" />
+									Clear
+								</Button>
+							</div>
+							<div className="flex items-center gap-2">
+								<Button
+									className="h-7 px-2 text-xs"
+									size="sm"
+									variant="secondary"
+									onClick={handleUnarchiveSelected}
+								>
+									<ArchiveBoxIcon className="mr-1 h-3 w-3" />
+									Unarchive {selectedArchivedChats.size}
+								</Button>
+								<AlertDialog>
+									<AlertDialogTrigger
+										render={
+											<Button
+												className="h-7 px-2 text-xs"
+												size="sm"
+												variant="destructive"
+											/>
+										}
+									>
+										<TrashIcon className="mr-1 h-3 w-3" />
+										Delete {selectedArchivedChats.size}
+									</AlertDialogTrigger>
+									<AlertDialogContent>
+										<AlertDialogHeader>
+											<AlertDialogTitle>
+												Delete {selectedArchivedChats.size} conversation
+												{selectedArchivedChats.size > 1 ? "s" : ""}
+											</AlertDialogTitle>
+											<AlertDialogDescription>
+												Are you sure you want to delete these conversations?
+												This action cannot be undone.
+											</AlertDialogDescription>
+										</AlertDialogHeader>
+										<AlertDialogFooter>
+											<AlertDialogCancel>Cancel</AlertDialogCancel>
+											<AlertDialogAction
+												variant="destructive"
+												disabled={deleteChatMutation.isPending}
+												onClick={handleDeleteSelectedArchived}
+											>
+												{deleteChatMutation.isPending
+													? "Deleting..."
+													: "Delete"}
+											</AlertDialogAction>
+										</AlertDialogFooter>
+									</AlertDialogContent>
+								</AlertDialog>
+							</div>
 						</div>
 					)}
 				</div>

--- a/src/components/chat-history-manager.tsx
+++ b/src/components/chat-history-manager.tsx
@@ -467,134 +467,142 @@ export default function ChatHistoryManager() {
 			)}
 
 			{/* Archived chats toggle */}
-			{archivedChats.length > 0 && (
-				<div className="mt-6 flex items-center gap-3">
-					<Switch
-						checked={showArchived}
-						onCheckedChange={setShowArchived}
-						size="sm"
-						id="show-archived"
-					/>
-					<Label
-						className="cursor-pointer text-sm text-muted-foreground"
-						htmlFor="show-archived"
+			<div className="mt-6 flex items-center gap-3">
+				<Switch
+					checked={showArchived}
+					onCheckedChange={setShowArchived}
+					size="sm"
+					id="show-archived"
+				/>
+				<Label
+					className="cursor-pointer text-sm text-muted-foreground"
+					htmlFor="show-archived"
+				>
+					Archived chats
+				</Label>
+				{showArchived && archivedChats.length > 0 && (
+					<Badge
+						className="h-4 px-1 text-[0.625rem] font-medium"
+						variant="secondary"
 					>
-						Archived chats
-					</Label>
-					{showArchived && (
-						<Badge
-							className="h-4 px-1 text-[0.625rem] font-medium"
-							variant="secondary"
-						>
-							{archivedChats.length}
-						</Badge>
-					)}
-				</div>
-			)}
+						{archivedChats.length}
+					</Badge>
+				)}
+			</div>
 
 			{/* Archived chats list */}
-			{showArchived && archivedChats.length > 0 && (
-				<div className="relative rounded-lg border">
-					<ScrollArea className="max-h-[300px]">
-						<div
-							className={`space-y-5 p-3 ${selectedArchivedChats.size > 0 ? "pb-14" : ""}`}
-						>
-							{groupedArchived.map(({ group, chats: groupChats }) => (
-								<div className="space-y-1" key={`archived-${group}`}>
-									<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
-										{group}
-									</h4>
-									<div className="space-y-0.5">
-										{groupChats.map((chat) =>
-											renderChatRow(chat, {
-												isArchived: true,
-												selectionSet: selectedArchivedChats,
-												onSelect: handleSelectArchivedChat,
-											}),
-										)}
+			{showArchived &&
+				(archivedChats.length > 0 ? (
+					<div className="relative rounded-lg border">
+						<ScrollArea className="max-h-[300px]">
+							<div
+								className={`space-y-5 p-3 ${selectedArchivedChats.size > 0 ? "pb-14" : ""}`}
+							>
+								{groupedArchived.map(({ group, chats: groupChats }) => (
+									<div className="space-y-1" key={`archived-${group}`}>
+										<h4 className="sticky top-0 z-10 bg-background px-2 py-1 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
+											{group}
+										</h4>
+										<div className="space-y-0.5">
+											{groupChats.map((chat) =>
+												renderChatRow(chat, {
+													isArchived: true,
+													selectionSet: selectedArchivedChats,
+													onSelect: handleSelectArchivedChat,
+												}),
+											)}
+										</div>
 									</div>
-								</div>
-							))}
-						</div>
-					</ScrollArea>
+								))}
+							</div>
+						</ScrollArea>
 
-					{/* Floating selection bar for archived */}
-					{selectedArchivedChats.size > 0 && (
-						<div className="absolute right-0 bottom-0 left-0 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
-							<div className="flex items-center gap-2">
-								<Button
-									className="h-7 px-2 text-xs"
-									size="sm"
-									variant="ghost"
-									onClick={handleSelectAllArchived}
-								>
-									{selectedArchivedChats.size === archivedChats.length
-										? "Deselect all"
-										: "Select all"}
-								</Button>
-								<Button
-									className="h-7 px-2 text-xs"
-									size="sm"
-									variant="ghost"
-									onClick={() => setSelectedArchivedChats(new Set())}
-								>
-									<XIcon className="mr-1 h-3 w-3" />
-									Clear
-								</Button>
-							</div>
-							<div className="flex items-center gap-2">
-								<Button
-									className="h-7 px-2 text-xs"
-									size="sm"
-									variant="secondary"
-									onClick={handleUnarchiveSelected}
-								>
-									<ArchiveBoxIcon className="mr-1 h-3 w-3" />
-									Unarchive {selectedArchivedChats.size}
-								</Button>
-								<AlertDialog>
-									<AlertDialogTrigger
-										render={
-											<Button
-												className="h-7 px-2 text-xs"
-												size="sm"
-												variant="destructive"
-											/>
-										}
+						{/* Floating selection bar for archived */}
+						{selectedArchivedChats.size > 0 && (
+							<div className="absolute right-0 bottom-0 left-0 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
+								<div className="flex items-center gap-2">
+									<Button
+										className="h-7 px-2 text-xs"
+										size="sm"
+										variant="ghost"
+										onClick={handleSelectAllArchived}
 									>
-										<TrashIcon className="mr-1 h-3 w-3" />
-										Delete {selectedArchivedChats.size}
-									</AlertDialogTrigger>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>
-												Delete {selectedArchivedChats.size} conversation
-												{selectedArchivedChats.size > 1 ? "s" : ""}
-											</AlertDialogTitle>
-											<AlertDialogDescription>
-												Are you sure you want to delete these conversations?
-												This action cannot be undone.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel>Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												variant="destructive"
-												disabled={deleteChatMutation.isPending}
-												onClick={handleDeleteSelectedArchived}
-											>
-												{deleteChatMutation.isPending
-													? "Deleting..."
-													: "Delete"}
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
+										{selectedArchivedChats.size === archivedChats.length
+											? "Deselect all"
+											: "Select all"}
+									</Button>
+									<Button
+										className="h-7 px-2 text-xs"
+										size="sm"
+										variant="ghost"
+										onClick={() => setSelectedArchivedChats(new Set())}
+									>
+										<XIcon className="mr-1 h-3 w-3" />
+										Clear
+									</Button>
+								</div>
+								<div className="flex items-center gap-2">
+									<Button
+										className="h-7 px-2 text-xs"
+										size="sm"
+										variant="secondary"
+										onClick={handleUnarchiveSelected}
+									>
+										<ArchiveBoxIcon className="mr-1 h-3 w-3" />
+										Unarchive {selectedArchivedChats.size}
+									</Button>
+									<AlertDialog>
+										<AlertDialogTrigger
+											render={
+												<Button
+													className="h-7 px-2 text-xs"
+													size="sm"
+													variant="destructive"
+												/>
+											}
+										>
+											<TrashIcon className="mr-1 h-3 w-3" />
+											Delete {selectedArchivedChats.size}
+										</AlertDialogTrigger>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>
+													Delete {selectedArchivedChats.size} conversation
+													{selectedArchivedChats.size > 1 ? "s" : ""}
+												</AlertDialogTitle>
+												<AlertDialogDescription>
+													Are you sure you want to delete these conversations?
+													This action cannot be undone.
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel>Cancel</AlertDialogCancel>
+												<AlertDialogAction
+													variant="destructive"
+													disabled={deleteChatMutation.isPending}
+													onClick={handleDeleteSelectedArchived}
+												>
+													{deleteChatMutation.isPending
+														? "Deleting..."
+														: "Delete"}
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
+								</div>
 							</div>
-						</div>
-					)}
-				</div>
-			)}
+						)}
+					</div>
+				) : (
+					<div className="flex flex-col items-center justify-center rounded-lg border py-10 text-center">
+						<p className="text-sm font-medium text-foreground">
+							No archived chats
+						</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Archive a conversation to see it here
+						</p>
+					</div>
+				))}
 		</TabsContent>
 	);
 }

--- a/src/components/chat-history-manager.tsx
+++ b/src/components/chat-history-manager.tsx
@@ -52,6 +52,11 @@ export default function ChatHistoryManager() {
 		mutationFn: useConvexMutation(api.chats.toggleChatArchive),
 		onSuccess: (wasArchived) => {
 			toast.success(wasArchived ? "Chat unarchived" : "Chat archived");
+			if (wasArchived) {
+				chatHistorySelectionActions.clearArchivedChatSelection();
+			} else {
+				chatHistorySelectionActions.clearChatSelection();
+			}
 		},
 		onError: () => {
 			toast.error("Failed to archive chat", {

--- a/src/components/chat-history-search.tsx
+++ b/src/components/chat-history-search.tsx
@@ -1,0 +1,24 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import {
+	chatHistorySelectionActions,
+	useChatHistorySelectionStore,
+} from "~/stores/chat-history-selection-store";
+import { Input } from "./ui/input";
+
+export default function ChatHistorySearch() {
+	const searchQuery = useChatHistorySelectionStore((s) => s.searchQuery);
+
+	return (
+		<div className="relative">
+			<MagnifyingGlassIcon className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+			<Input
+				className="h-8 rounded-lg border bg-transparent py-0 pl-8 text-xs"
+				placeholder="Search conversations..."
+				value={searchQuery}
+				onChange={(e) =>
+					chatHistorySelectionActions.setSearchQuery(e.target.value)
+				}
+			/>
+		</div>
+	);
+}

--- a/src/components/chat-history-selection-bar.tsx
+++ b/src/components/chat-history-selection-bar.tsx
@@ -1,0 +1,120 @@
+import { ArchiveBoxIcon, TrashIcon, XIcon } from "@phosphor-icons/react";
+import {
+	chatHistorySelectionActions,
+	useChatHistorySelectionStore,
+} from "~/stores/chat-history-selection-store";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
+
+type Props = {
+	isArchived: boolean;
+	isAllSelected: boolean;
+	onSelectAll: () => void;
+	onArchiveAction: () => void;
+	onDeleteAction: () => void;
+	isDeletePending: boolean;
+};
+
+export default function ChatHistorySelectionBar({
+	isArchived,
+	isAllSelected,
+	onSelectAll,
+	onArchiveAction,
+	onDeleteAction,
+	isDeletePending,
+}: Props) {
+	const selectedCount = useChatHistorySelectionStore((s) =>
+		isArchived ? s.selectedArchivedChatIds.length : s.selectedChatIds.length,
+	);
+
+	const handleClear = () => {
+		if (isArchived) {
+			chatHistorySelectionActions.clearArchivedChatSelection();
+		} else {
+			chatHistorySelectionActions.clearChatSelection();
+		}
+	};
+
+	const archiveLabel = isArchived ? "Unarchive" : "Archive";
+
+	return (
+		<div className="absolute right-0 bottom-0 left-0 z-20 flex items-center justify-between rounded-b-lg border-t bg-background/95 px-3 py-2 backdrop-blur-sm">
+			<div className="flex items-center gap-2">
+				<Button
+					className="h-7 px-2 text-xs"
+					size="sm"
+					variant="ghost"
+					onClick={onSelectAll}
+				>
+					{isAllSelected ? "Deselect all" : "Select all"}
+				</Button>
+				<Button
+					className="h-7 px-2 text-xs"
+					size="sm"
+					variant="ghost"
+					onClick={handleClear}
+				>
+					<XIcon className="mr-1 h-3 w-3" />
+					Clear
+				</Button>
+			</div>
+			<div className="flex items-center gap-2">
+				<Button
+					className="h-7 gap-1 px-2 text-xs"
+					size="sm"
+					variant="secondary"
+					onClick={onArchiveAction}
+				>
+					<ArchiveBoxIcon className="h-3 w-3" />
+					{archiveLabel} {selectedCount}
+				</Button>
+				<AlertDialog>
+					<AlertDialogTrigger
+						render={
+							<Button
+								className="h-7 px-2 text-xs"
+								size="sm"
+								variant="destructive"
+							/>
+						}
+					>
+						<TrashIcon className="mr-1 h-3 w-3" />
+						Delete {selectedCount}
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>
+								Delete {selectedCount} conversation
+								{selectedCount > 1 ? "s" : ""}
+							</AlertDialogTitle>
+							<AlertDialogDescription>
+								Are you sure you want to delete these conversations? This action
+								cannot be undone.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction
+								variant="destructive"
+								disabled={isDeletePending}
+								onClick={onDeleteAction}
+							>
+								{isDeletePending ? "Deleting..." : "Delete"}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</div>
+		</div>
+	);
+}

--- a/src/stores/chat-history-selection-store.ts
+++ b/src/stores/chat-history-selection-store.ts
@@ -1,0 +1,81 @@
+import { useSelector } from "@tanstack/react-store";
+import { Store } from "@tanstack/store";
+
+interface ChatHistorySelectionState {
+	selectedChatIds: string[];
+	selectedArchivedChatIds: string[];
+	searchQuery: string;
+	showArchived: boolean;
+}
+
+const chatHistorySelectionStore = new Store<ChatHistorySelectionState>({
+	selectedChatIds: [],
+	selectedArchivedChatIds: [],
+	searchQuery: "",
+	showArchived: false,
+});
+
+export const useChatHistorySelectionStore = <T>(
+	selector: (state: ChatHistorySelectionState) => T,
+): T => useSelector(chatHistorySelectionStore, selector);
+
+export const chatHistorySelectionActions = {
+	toggleChat: (chatId: string) => {
+		chatHistorySelectionStore.setState((prev) => {
+			const has = prev.selectedChatIds.includes(chatId);
+			return {
+				...prev,
+				selectedChatIds: has
+					? prev.selectedChatIds.filter((id) => id !== chatId)
+					: [...prev.selectedChatIds, chatId],
+			};
+		});
+	},
+	selectAllChats: (chatIds: string[]) => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			selectedChatIds: chatIds,
+		}));
+	},
+	clearChatSelection: () => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			selectedChatIds: [],
+		}));
+	},
+	toggleArchivedChat: (chatId: string) => {
+		chatHistorySelectionStore.setState((prev) => {
+			const has = prev.selectedArchivedChatIds.includes(chatId);
+			return {
+				...prev,
+				selectedArchivedChatIds: has
+					? prev.selectedArchivedChatIds.filter((id) => id !== chatId)
+					: [...prev.selectedArchivedChatIds, chatId],
+			};
+		});
+	},
+	selectAllArchivedChats: (chatIds: string[]) => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			selectedArchivedChatIds: chatIds,
+		}));
+	},
+	clearArchivedChatSelection: () => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			selectedArchivedChatIds: [],
+		}));
+	},
+	setSearchQuery: (query: string) => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			searchQuery: query,
+		}));
+	},
+	setShowArchived: (show: boolean) => {
+		chatHistorySelectionStore.setState((prev) => ({
+			...prev,
+			showArchived: show,
+		}));
+	},
+};

--- a/src/stores/chat-history-selection-store.ts
+++ b/src/stores/chat-history-selection-store.ts
@@ -34,7 +34,7 @@ export const chatHistorySelectionActions = {
 	selectAllChats: (chatIds: string[]) => {
 		chatHistorySelectionStore.setState((prev) => ({
 			...prev,
-			selectedChatIds: chatIds,
+			selectedChatIds: [...chatIds],
 		}));
 	},
 	clearChatSelection: () => {
@@ -57,7 +57,7 @@ export const chatHistorySelectionActions = {
 	selectAllArchivedChats: (chatIds: string[]) => {
 		chatHistorySelectionStore.setState((prev) => ({
 			...prev,
-			selectedArchivedChatIds: chatIds,
+			selectedArchivedChatIds: [...chatIds],
 		}));
 	},
 	clearArchivedChatSelection: () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,13 @@ export type CustomUIMessage = Omit<UIMessage<MessageMetadata>, "role"> & {
 	role: "user" | "assistant";
 };
 
+export type ChatHistoryItem = {
+	_id: string;
+	_creationTime: number;
+	title: string;
+	isBranched: boolean;
+};
+
 export type AppFont = "font-mono" | "font-sans";
 
 export type ChatSendMessageFunction =


### PR DESCRIPTION
Fixes #100 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add chat archiving with single and bulk archive/unarchive, and a separate Archived list that stays out of the main history. The Chat History UI is refactored with selection, search, improved empty/loading states, and an always-visible Archived header.

- **New Features**
  - Data: add `isArchived` to chats; new indexes `by_user_and_pinned_and_folder_and_archived` and `by_user_and_archived`; active lists filter to `isArchived: false`.
  - API: `getArchivedChats`, `toggleChatArchive` (clears relevant selection after toggle), `archiveAll`, `unarchiveAll`; `createChat` and branched chats default to `isArchived: false`.
  - UI: archive action in chat item menu; Archived toggle with count and empty state; grouped Archived list; bulk selection bar for archive/unarchive/delete; search and persistent selection via `@tanstack/store`; toasts.

- **Migration**
  - Run `migrations/setAllChatsUnarchived.setAllChatsUnarchived` once to backfill `isArchived: false` for existing chats.

<sup>Written for commit 59810efb43995a6ee267122253ba78d9463a02d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



