### PR TITLE
revert changes in code-higlight component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "baychat",

--- a/src/components/code-highlight.tsx
+++ b/src/components/code-highlight.tsx
@@ -1,18 +1,18 @@
 import { CopyIcon, TextAlignLeftIcon } from "@phosphor-icons/react";
 import { useTheme } from "next-themes";
-import { useState, type ComponentPropsWithoutRef } from "react";
-import type { ExtraProps } from "react-markdown";
-import ShikiHighlighter, {
-	type Element as ShikiElement,
-	isInlineCode,
-} from "react-shiki";
+import { useState, type ReactNode } from "react";
+import ShikiHighlighter, { type Element, isInlineCode } from "react-shiki";
 import { toast } from "sonner";
 import { cn } from "~/lib/utils";
 import { Button } from "./ui/button";
 import { Toggle } from "./ui/toggle";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
-type CodeHighlightProps = ComponentPropsWithoutRef<"code"> & ExtraProps;
+type CodeHighlightProps = {
+	className?: string | undefined;
+	children?: ReactNode | undefined;
+	node?: Element | undefined;
+};
 
 export default function CodeHighlight({
 	className,
@@ -25,9 +25,7 @@ export default function CodeHighlight({
 	const match = className?.match(/language-(\w+)/);
 	const language = match ? match[1] : undefined;
 
-	const isInline: boolean | undefined = node
-		? isInlineCode(node as unknown as ShikiElement)
-		: undefined;
+	const isInline: boolean | undefined = node ? isInlineCode(node) : undefined;
 	const codeContent = String(children);
 
 	if (isInline) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverted the `CodeHighlight` component to a stable implementation to stop SSR crashes when rendering code blocks. No UI changes; server rendering for inline and block code works again.

- **Bug Fixes**
  - Replaced `ComponentPropsWithoutRef<"code"> & ExtraProps` with a minimal props type (`className`, `children`, `node`) compatible with `react-shiki`.
  - Switched to `Element` from `react-shiki` and use `isInlineCode(node)` directly to avoid unsafe casts.
  - Updated `bun.lock` metadata (`configVersion`) with no runtime impact.

<sup>Written for commit 0fdf6bd8cd15e9588b71e9fdf4e39119cc2c1c1d. Summary will update on new commits. <a href="https://cubic.dev/pr/ankitk26/baychat/pull/111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

