### PR TITLE
auto-expand folder containing the active chat

### DIFF
--- a/src/components/app-sidebar-folder-item.tsx
+++ b/src/components/app-sidebar-folder-item.tsx
@@ -1,3 +1,4 @@
+import { useParams } from "@tanstack/react-router";
 import { useState } from "react";
 import type { SidebarFolder } from "~/types";
 import AppSidebarChatItem from "./app-sidebar-chat-item";
@@ -15,12 +16,31 @@ type Props = {
 };
 
 export default function AppSidebarFolderItem(props: Props) {
-	const [showChats, setShowChats] = useState(false);
+	const { chatId } = useParams({ strict: false });
+	const [manualExpand, setManualExpand] = useState(false);
+	const [collapsedAtChatId, setCollapsedAtChatId] = useState<string | null>(
+		null,
+	);
 	const { isMobile } = useSidebar();
+
+	const isActiveChatInFolder =
+		chatId != null && props.folder.chats.some((chat) => chat.uuid === chatId);
+
+	// User collapsed while viewing this chat — but if chatId changed since,
+	// ignore the collapse so the new folder auto-expands.
+	const userCollapsed = collapsedAtChatId === chatId;
+	const showChats = isActiveChatInFolder ? !userCollapsed : manualExpand;
 
 	const handleClick = (e: React.MouseEvent) => {
 		e.preventDefault();
-		setShowChats((prev) => !prev);
+		if (showChats && isActiveChatInFolder) {
+			setCollapsedAtChatId(chatId ?? null);
+		} else if (showChats) {
+			setManualExpand(false);
+		} else {
+			setManualExpand(true);
+			setCollapsedAtChatId(null);
+		}
 	};
 
 	return (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-expands the sidebar folder that contains the active chat. Keeps it collapsed only if the user collapsed it while viewing that same chat.

- **New Features**
  - Reads `chatId` from `@tanstack/react-router` to detect the active chat.
  - Auto-expands the folder containing the active chat; remembers per-chat collapses via `collapsedAtChatId`.
  - Manual expand/collapse still works for other cases and when switching chats.

<sup>Written for commit a1b69de6558e5f3f1c9d07cdad1f17b82892f59a. Summary will update on new commits. <a href="https://cubic.dev/pr/ankitk26/baychat/pull/113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

