### PR TITLE
Table of contents

### DIFF
--- a/src/components/chat-messages.tsx
+++ b/src/components/chat-messages.tsx
@@ -33,7 +33,11 @@ export default memo(function ChatMessages({
 	return (
 		<div className="space-y-6 px-3 lg:space-y-8 lg:px-0">
 			{messages.map((message, index) => (
-				<div className="flex flex-col" key={message.id}>
+				<div
+					className="flex scroll-mt-6 flex-col"
+					key={message.id}
+					id={message.id}
+				>
 					{message.role === "user" ? (
 						<UserMessage
 							chatId={chatId}

--- a/src/components/chat-table-of-contents-sidebar.tsx
+++ b/src/components/chat-table-of-contents-sidebar.tsx
@@ -3,19 +3,18 @@ import { memo, useMemo } from "react";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { extractTableOfContents } from "~/lib/extract-table-of-contents";
 import { cn } from "~/lib/utils";
+import {
+	tableOfContentsStoreActions,
+	useTableOfContentsStore,
+} from "~/stores/table-of-contents-store";
 import type { CustomUIMessage } from "~/types";
 
 type Props = {
 	messages: CustomUIMessage[];
-	isOpen: boolean;
-	onToggle: () => void;
 };
 
-export default memo(function ChatTableOfContentsSidebar({
-	messages,
-	isOpen,
-	onToggle,
-}: Props) {
+export default memo(function ChatTableOfContentsSidebar({ messages }: Props) {
+	const isOpen = useTableOfContentsStore((state) => state.isOpen);
 	const sections = useMemo(() => extractTableOfContents(messages), [messages]);
 
 	const handleNavigate = (id: string) => {
@@ -37,7 +36,7 @@ export default memo(function ChatTableOfContentsSidebar({
 			<div className="flex h-14 shrink-0 items-center justify-between border-b px-4">
 				<h2 className="text-sm font-semibold">Contents</h2>
 				<button
-					onClick={onToggle}
+					onClick={tableOfContentsStoreActions.close}
 					className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
 					type="button"
 				>

--- a/src/components/chat-table-of-contents-sidebar.tsx
+++ b/src/components/chat-table-of-contents-sidebar.tsx
@@ -20,7 +20,7 @@ export default memo(function ChatTableOfContentsSidebar({ messages }: Props) {
 	const handleNavigate = (id: string) => {
 		const element = document.getElementById(id);
 		if (element) {
-			element.scrollIntoView({ behavior: "smooth", block: "start" });
+			element.scrollIntoView({ behavior: "instant", block: "start" });
 		}
 	};
 

--- a/src/components/chat-table-of-contents-sidebar.tsx
+++ b/src/components/chat-table-of-contents-sidebar.tsx
@@ -1,0 +1,89 @@
+import { XIcon } from "@phosphor-icons/react";
+import { memo, useMemo } from "react";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import { extractTableOfContents } from "~/lib/extract-table-of-contents";
+import { cn } from "~/lib/utils";
+import type { CustomUIMessage } from "~/types";
+
+type Props = {
+	messages: CustomUIMessage[];
+	isOpen: boolean;
+	onToggle: () => void;
+};
+
+export default memo(function ChatTableOfContentsSidebar({
+	messages,
+	isOpen,
+	onToggle,
+}: Props) {
+	const sections = useMemo(() => extractTableOfContents(messages), [messages]);
+
+	const handleNavigate = (id: string) => {
+		const element = document.getElementById(id);
+		if (element) {
+			element.scrollIntoView({ behavior: "smooth", block: "start" });
+		}
+	};
+
+	return (
+		<div
+			className={cn(
+				"hidden h-full shrink-0 flex-col border-l bg-background transition-all duration-300 ease-in-out md:flex",
+				isOpen
+					? "w-64 opacity-100"
+					: "w-0 overflow-hidden border-transparent opacity-0",
+			)}
+		>
+			<div className="flex h-14 shrink-0 items-center justify-between border-b px-4">
+				<h2 className="text-sm font-semibold">Contents</h2>
+				<button
+					onClick={onToggle}
+					className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+					type="button"
+				>
+					<XIcon className="size-4" />
+				</button>
+			</div>
+
+			<ScrollArea className="flex-1">
+				<div className="py-2">
+					{sections.length === 0 && (
+						<p className="px-4 py-2 text-xs text-muted-foreground">
+							No contents yet
+						</p>
+					)}
+
+					{sections.map((section) => (
+						<div key={section.turnId} className="px-2 py-0.5">
+							<button
+								onClick={() => handleNavigate(section.turnId)}
+								className="w-full rounded px-2 py-1.5 text-left text-xs font-medium hover:bg-accent"
+								type="button"
+							>
+								{section.userPreview}
+							</button>
+
+							{section.headings.length > 0 && (
+								<div className="mt-0.5 ml-2 border-l pl-2">
+									{section.headings.map((heading, idx) => (
+										<button
+											key={idx}
+											onClick={() => handleNavigate(heading.headingId)}
+											className={cn(
+												"w-full truncate rounded px-2 py-1 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground",
+												heading.depth <= 2 && "font-medium text-foreground/80",
+											)}
+											type="button"
+										>
+											{heading.text}
+										</button>
+									))}
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			</ScrollArea>
+		</div>
+	);
+});

--- a/src/components/chat-table-of-contents-toggle.tsx
+++ b/src/components/chat-table-of-contents-toggle.tsx
@@ -1,23 +1,25 @@
-import { ListIcon, XIcon } from "@phosphor-icons/react";
+import { ListIcon } from "@phosphor-icons/react";
 import { Button } from "~/components/ui/button";
-import { cn } from "~/lib/utils";
+import {
+	tableOfContentsStoreActions,
+	useTableOfContentsStore,
+} from "~/stores/table-of-contents-store";
 
-type Props = {
-	isOpen: boolean;
-	onToggle: () => void;
-};
+export default function ChatTableOfContentsToggle() {
+	const isOpen = useTableOfContentsStore((state) => state.isOpen);
 
-export default function ChatTableOfContentsToggle({ isOpen, onToggle }: Props) {
+	if (isOpen) {
+		return null;
+	}
+
 	return (
 		<Button
-			className={cn(
-				"absolute top-3 right-3 z-20 hidden h-8 w-8 rounded-md shadow-sm transition-opacity duration-200 md:flex",
-			)}
-			onClick={onToggle}
+			className="absolute top-3 right-3 z-20 hidden h-8 w-8 rounded-md shadow-sm transition-opacity duration-200 md:flex"
+			onClick={tableOfContentsStoreActions.open}
 			size="icon"
 			variant="secondary"
 		>
-			{isOpen ? <XIcon className="size-4" /> : <ListIcon className="size-4" />}
+			<ListIcon className="size-4" />
 		</Button>
 	);
 }

--- a/src/components/chat-table-of-contents-toggle.tsx
+++ b/src/components/chat-table-of-contents-toggle.tsx
@@ -1,0 +1,23 @@
+import { ListIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+type Props = {
+	isOpen: boolean;
+	onToggle: () => void;
+};
+
+export default function ChatTableOfContentsToggle({ isOpen, onToggle }: Props) {
+	return (
+		<Button
+			className={cn(
+				"absolute top-3 right-3 z-20 hidden h-8 w-8 rounded-md shadow-sm transition-opacity duration-200 md:flex",
+			)}
+			onClick={onToggle}
+			size="icon"
+			variant="secondary"
+		>
+			{isOpen ? <XIcon className="size-4" /> : <ListIcon className="size-4" />}
+		</Button>
+	);
+}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -63,7 +63,6 @@ export default function Chat({
 	const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [inputHeight, setInputHeight] = useState(120); // Default estimate
 	const [wasStopped, setWasStopped] = useState(false);
-	const [tableOfContentsOpen, setTableOfContentsOpen] = useState(false);
 
 	const handleStop = () => {
 		setWasStopped(true);
@@ -249,21 +248,12 @@ export default function Chat({
 						/>
 					</div>
 
-					{!isMessagesPending &&
-						messages.length > 0 &&
-						!tableOfContentsOpen && (
-							<ChatTableOfContentsToggle
-								isOpen={tableOfContentsOpen}
-								onToggle={() => setTableOfContentsOpen(true)}
-							/>
-						)}
+					{!isMessagesPending && messages.length > 0 && (
+						<ChatTableOfContentsToggle />
+					)}
 				</div>
 
-				<ChatTableOfContentsSidebar
-					messages={messages}
-					isOpen={tableOfContentsOpen}
-					onToggle={() => setTableOfContentsOpen((prev) => !prev)}
-				/>
+				<ChatTableOfContentsSidebar messages={messages} />
 			</div>
 		</div>
 	);

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -2,6 +2,8 @@ import { useChat } from "@ai-sdk/react";
 import { CaretDownIcon } from "@phosphor-icons/react";
 import type { FileUIPart } from "ai";
 import { useEffect, useRef, useState } from "react";
+import ChatTableOfContentsSidebar from "~/components/chat-table-of-contents-sidebar";
+import ChatTableOfContentsToggle from "~/components/chat-table-of-contents-toggle";
 import { isImageGenerationModel } from "~/lib/is-image-generation-model";
 import { cn } from "~/lib/utils";
 import { useSharedChatContext } from "~/providers/chat-provider";
@@ -61,6 +63,7 @@ export default function Chat({
 	const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [inputHeight, setInputHeight] = useState(120); // Default estimate
 	const [wasStopped, setWasStopped] = useState(false);
+	const [tableOfContentsOpen, setTableOfContentsOpen] = useState(false);
 
 	const handleStop = () => {
 		setWasStopped(true);
@@ -155,87 +158,111 @@ export default function Chat({
 
 	return (
 		<div className="relative mx-auto flex h-full min-h-0 w-full flex-col">
-			{/* Full height scroll area that extends behind the prompt */}
-			<div className="absolute inset-0">
-				{!isMessagesPending && messages.length === 0 && <EmptyChatContent />}
+			<div className="flex h-full min-h-0">
+				{/* Main chat area */}
+				<div className="relative flex-1 overflow-hidden">
+					{/* Full height scroll area that extends behind the prompt */}
+					<div className="absolute inset-0">
+						{!isMessagesPending && messages.length === 0 && (
+							<EmptyChatContent />
+						)}
 
-				{chatId && (
-					<ScrollArea className="h-full w-full" viewportRef={viewportRef}>
-						<div className="mx-auto min-h-full w-full max-w-full px-3 lg:max-w-3xl lg:px-4">
-							<div
-								className="pb-safe my-4 space-y-6 lg:my-8 lg:space-y-8"
-								style={{ paddingBottom: `${inputHeight + 40}px` }}
-							>
-								{isMessagesPending && messages.length === 0 ? (
-									<>
-										<UserMessageSkeleton />
-										<AssistantMessageSkeleton />
-									</>
-								) : (
-									<>
-										<ChatMessages
-											chatId={chatId}
-											isGeneratingImage={isGeneratingImage}
-											latestGeneratedImageUrl={latestGeneratedImageUrl}
-											messages={messages}
-											regenerate={handleRegenerate}
-											sendMessage={handleSendMessage}
-											status={status}
-											wasStopped={wasStopped}
-										/>
+						{chatId && (
+							<ScrollArea className="h-full w-full" viewportRef={viewportRef}>
+								<div className="mx-auto min-h-full w-full max-w-full px-3 lg:max-w-3xl lg:px-4">
+									<div
+										className="pb-safe my-4 space-y-6 lg:my-8 lg:space-y-8"
+										style={{ paddingBottom: `${inputHeight + 40}px` }}
+									>
+										{isMessagesPending && messages.length === 0 ? (
+											<>
+												<UserMessageSkeleton />
+												<AssistantMessageSkeleton />
+											</>
+										) : (
+											<>
+												<ChatMessages
+													chatId={chatId}
+													isGeneratingImage={isGeneratingImage}
+													latestGeneratedImageUrl={latestGeneratedImageUrl}
+													messages={messages}
+													regenerate={handleRegenerate}
+													sendMessage={handleSendMessage}
+													status={status}
+													wasStopped={wasStopped}
+												/>
 
-										{status === "submitted" &&
-											messages.length > 0 &&
-											messages.at(-1)?.role === "user" &&
-											!error && (
-												<div className="px-3 lg:px-0">
-													{isGeneratingImage ? (
-														<ImageGenerationSkeleton />
-													) : (
-														<ThinkingIndicator />
+												{status === "submitted" &&
+													messages.length > 0 &&
+													messages.at(-1)?.role === "user" &&
+													!error && (
+														<div className="px-3 lg:px-0">
+															{isGeneratingImage ? (
+																<ImageGenerationSkeleton />
+															) : (
+																<ThinkingIndicator />
+															)}
+														</div>
 													)}
-												</div>
-											)}
 
-										{error && <AiResponseAlert error={error} />}
-									</>
-								)}
-							</div>
+												{error && <AiResponseAlert error={error} />}
+											</>
+										)}
+									</div>
+								</div>
+							</ScrollArea>
+						)}
+					</div>
+
+					{/* Scroll to bottom button - centered at top of prompt */}
+					{showScrollToBottom && (
+						<div
+							className={cn(
+								"absolute left-1/2 z-50 -translate-x-1/2 transform transition-opacity duration-300 ease-in-out",
+								isScrollActive
+									? "opacity-100"
+									: "pointer-events-none opacity-0",
+							)}
+							style={{ bottom: `${inputHeight + 16}px` }}
+						>
+							<Button
+								className="rounded-full"
+								onClick={scrollToBottom}
+								size="icon"
+								tabIndex={isScrollActive ? undefined : -1}
+								aria-hidden={!isScrollActive}
+							>
+								<CaretDownIcon />
+							</Button>
 						</div>
-					</ScrollArea>
-				)}
-			</div>
-
-			{/* Scroll to bottom button - centered at top of prompt */}
-			{showScrollToBottom && (
-				<div
-					className={cn(
-						"absolute left-1/2 z-50 -translate-x-1/2 transform transition-opacity duration-300 ease-in-out",
-						isScrollActive ? "opacity-100" : "pointer-events-none opacity-0",
 					)}
-					style={{ bottom: `${inputHeight + 16}px` }}
-				>
-					<Button
-						className="rounded-full"
-						onClick={scrollToBottom}
-						size="icon"
-						tabIndex={isScrollActive ? undefined : -1}
-						aria-hidden={!isScrollActive}
-					>
-						<CaretDownIcon />
-					</Button>
-				</div>
-			)}
 
-			{/* Fixed prompt input with backdrop blur */}
-			<div className="absolute right-0 bottom-0 left-0 z-10">
-				<UserPromptInput
-					chatId={chatId}
-					latestGeneratedImageUrl={latestGeneratedImageUrl}
-					sendMessage={handleSendMessage}
-					status={status}
-					stop={handleStop}
-					onHeightChange={setInputHeight}
+					{/* Fixed prompt input with backdrop blur */}
+					<div className="absolute right-0 bottom-0 left-0 z-10">
+						<UserPromptInput
+							chatId={chatId}
+							latestGeneratedImageUrl={latestGeneratedImageUrl}
+							sendMessage={handleSendMessage}
+							status={status}
+							stop={handleStop}
+							onHeightChange={setInputHeight}
+						/>
+					</div>
+
+					{!isMessagesPending &&
+						messages.length > 0 &&
+						!tableOfContentsOpen && (
+							<ChatTableOfContentsToggle
+								isOpen={tableOfContentsOpen}
+								onToggle={() => setTableOfContentsOpen(true)}
+							/>
+						)}
+				</div>
+
+				<ChatTableOfContentsSidebar
+					messages={messages}
+					isOpen={tableOfContentsOpen}
+					onToggle={() => setTableOfContentsOpen((prev) => !prev)}
 				/>
 			</div>
 		</div>

--- a/src/components/memoized-markdown.tsx
+++ b/src/components/memoized-markdown.tsx
@@ -31,7 +31,7 @@ function parseMarkdownIntoBlocks(markdown: string, messageId: string): Block[] {
 
 function makeHeadingWithId(tag: string, id: string) {
 	return function HeadingWithId({
-		_node,
+		node: _node,
 		className,
 		...props
 	}: Record<string, unknown>) {

--- a/src/components/memoized-markdown.tsx
+++ b/src/components/memoized-markdown.tsx
@@ -1,33 +1,84 @@
 import { marked } from "marked";
 import { memo, useMemo } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import CodeHighlight from "./code-highlight";
 
-function parseMarkdownIntoBlocks(markdown: string): string[] {
+type Block = {
+	raw: string;
+	headingId?: string;
+	headingDepth?: number;
+};
+
+function parseMarkdownIntoBlocks(markdown: string, messageId: string): Block[] {
 	const tokens = marked.lexer(markdown);
-	return tokens.map((token) => token.raw);
+	let headingIndex = 0;
+	return tokens.map((token) => {
+		if (token.type === "heading") {
+			const id = `${messageId}-heading-${headingIndex}`;
+			headingIndex++;
+			return {
+				raw: token.raw,
+				headingId: id,
+				headingDepth: token.depth,
+			};
+		}
+		return { raw: token.raw };
+	});
+}
+
+function makeHeadingWithId(tag: string, id: string) {
+	return function HeadingWithId({
+		_node,
+		className,
+		...props
+	}: Record<string, unknown>) {
+		const Tag = tag as keyof JSX.IntrinsicElements;
+		const mergedClass = `scroll-mt-6 ${(className as string) || ""}`.trim();
+		return <Tag id={id} className={mergedClass} {...props} />;
+	};
 }
 
 const MemoizedMarkdownBlock = memo(
-	({ content }: { content: string }) => (
-		<ReactMarkdown
-			components={{
-				code: CodeHighlight,
-			}}
-			rehypePlugins={[rehypeKatex]}
-			remarkPlugins={[remarkGfm, remarkMath]}
-		>
-			{content}
-		</ReactMarkdown>
-	),
-	(prevProps, nextProps) => {
-		if (prevProps.content !== nextProps.content) {
-			return false;
+	({
+		content,
+		headingId,
+		headingDepth,
+	}: {
+		content: string;
+		headingId?: string;
+		headingDepth?: number;
+	}) => {
+		const components: Partial<Components> = {
+			code: CodeHighlight,
+		};
+
+		if (headingId && headingDepth) {
+			const tag = `h${headingDepth}`;
+			components[tag as keyof Components] = makeHeadingWithId(
+				tag,
+				headingId,
+			) as Components[keyof Components];
 		}
-		return true;
+
+		return (
+			<ReactMarkdown
+				components={components}
+				rehypePlugins={[rehypeKatex]}
+				remarkPlugins={[remarkGfm, remarkMath]}
+			>
+				{content}
+			</ReactMarkdown>
+		);
+	},
+	(prevProps, nextProps) => {
+		return (
+			prevProps.content === nextProps.content &&
+			prevProps.headingId === nextProps.headingId &&
+			prevProps.headingDepth === nextProps.headingDepth
+		);
 	},
 );
 
@@ -37,10 +88,20 @@ type Props = {
 };
 
 export default memo(function MemoizedMarkdown({ content, id }: Props) {
-	const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
+	const blocks = useMemo(
+		() => parseMarkdownIntoBlocks(content, id),
+		[content, id],
+	);
 
 	return blocks.map((block, index) => {
 		const key = `${id}-block_${index}`;
-		return <MemoizedMarkdownBlock content={block} key={key} />;
+		return (
+			<MemoizedMarkdownBlock
+				content={block.raw}
+				key={key}
+				headingId={block.headingId}
+				headingDepth={block.headingDepth}
+			/>
+		);
 	});
 });

--- a/src/components/memoized-markdown.tsx
+++ b/src/components/memoized-markdown.tsx
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import { memo, useMemo } from "react";
+import { type HTMLAttributes, memo, useMemo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
@@ -10,6 +10,10 @@ type Block = {
 	raw: string;
 	headingId?: string;
 	headingDepth?: number;
+};
+
+type HeadingProps = HTMLAttributes<HTMLHeadingElement> & {
+	node?: unknown;
 };
 
 function parseMarkdownIntoBlocks(markdown: string, messageId: string): Block[] {
@@ -34,10 +38,25 @@ function makeHeadingWithId(tag: string, id: string) {
 		node: _node,
 		className,
 		...props
-	}: Record<string, unknown>) {
-		const Tag = tag as keyof JSX.IntrinsicElements;
-		const mergedClass = `scroll-mt-6 ${(className as string) || ""}`.trim();
-		return <Tag id={id} className={mergedClass} {...props} />;
+	}: HeadingProps) {
+		const mergedClass = `scroll-mt-6 ${className || ""}`.trim();
+
+		switch (tag) {
+			case "h1":
+				return <h1 id={id} className={mergedClass} {...props} />;
+			case "h2":
+				return <h2 id={id} className={mergedClass} {...props} />;
+			case "h3":
+				return <h3 id={id} className={mergedClass} {...props} />;
+			case "h4":
+				return <h4 id={id} className={mergedClass} {...props} />;
+			case "h5":
+				return <h5 id={id} className={mergedClass} {...props} />;
+			case "h6":
+				return <h6 id={id} className={mergedClass} {...props} />;
+			default:
+				return null;
+		}
 	};
 }
 
@@ -57,10 +76,28 @@ const MemoizedMarkdownBlock = memo(
 
 		if (headingId && headingDepth) {
 			const tag = `h${headingDepth}`;
-			components[tag as keyof Components] = makeHeadingWithId(
-				tag,
-				headingId,
-			) as Components[keyof Components];
+			const HeadingComponent = makeHeadingWithId(tag, headingId);
+
+			switch (tag) {
+				case "h1":
+					components.h1 = HeadingComponent;
+					break;
+				case "h2":
+					components.h2 = HeadingComponent;
+					break;
+				case "h3":
+					components.h3 = HeadingComponent;
+					break;
+				case "h4":
+					components.h4 = HeadingComponent;
+					break;
+				case "h5":
+					components.h5 = HeadingComponent;
+					break;
+				case "h6":
+					components.h6 = HeadingComponent;
+					break;
+			}
 		}
 
 		return (

--- a/src/lib/extract-table-of-contents.ts
+++ b/src/lib/extract-table-of-contents.ts
@@ -1,0 +1,61 @@
+import { marked } from "marked";
+import type { CustomUIMessage, TableOfContentsSection } from "~/types";
+
+function getTextFromMessage(message: CustomUIMessage): string {
+	return message.parts
+		.filter((p) => p.type === "text")
+		.map((p) => ("text" in p ? p.text : ""))
+		.join(" ")
+		.trim();
+}
+
+export function extractTableOfContents(
+	messages: CustomUIMessage[],
+): TableOfContentsSection[] {
+	const sections: TableOfContentsSection[] = [];
+
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i];
+		if (message.role !== "user") continue;
+
+		const userContent = getTextFromMessage(message);
+		const preview =
+			userContent.slice(0, 42) + (userContent.length > 42 ? "…" : "") ||
+			"Empty message";
+
+		const nextMessage = messages[i + 1];
+		const headings: TableOfContentsSection["headings"] = [];
+		let assistantId: string | undefined;
+
+		if (nextMessage?.role === "assistant") {
+			assistantId = nextMessage.id;
+			const textParts = getTextFromMessage(nextMessage);
+
+			try {
+				const tokens = marked.lexer(textParts);
+				let headingIndex = 0;
+				for (const token of tokens) {
+					if (token.type === "heading") {
+						headings.push({
+							text: token.text,
+							depth: token.depth,
+							headingId: `${assistantId}-heading-${headingIndex}`,
+						});
+						headingIndex++;
+					}
+				}
+			} catch {
+				// ignore markdown parsing errors
+			}
+		}
+
+		sections.push({
+			turnId: message.id,
+			userPreview: preview,
+			assistantId,
+			headings,
+		});
+	}
+
+	return sections;
+}

--- a/src/lib/extract-table-of-contents.ts
+++ b/src/lib/extract-table-of-contents.ts
@@ -5,7 +5,7 @@ function getTextFromMessage(message: CustomUIMessage): string {
 	return message.parts
 		.filter((p) => p.type === "text")
 		.map((p) => ("text" in p ? p.text : ""))
-		.join(" ")
+		.join("")
 		.trim();
 }
 

--- a/src/stores/table-of-contents-store.ts
+++ b/src/stores/table-of-contents-store.ts
@@ -1,0 +1,29 @@
+import { useSelector } from "@tanstack/react-store";
+import { Store } from "@tanstack/store";
+
+type TableOfContentsStoreState = {
+	isOpen: boolean;
+};
+
+const tableOfContentsStore = new Store<TableOfContentsStoreState>({
+	isOpen: false,
+});
+
+export const useTableOfContentsStore = <T>(
+	selector: (state: TableOfContentsStoreState) => T,
+): T => useSelector(tableOfContentsStore, selector);
+
+export const tableOfContentsStoreActions = {
+	open: () => {
+		tableOfContentsStore.setState((prev) => ({ ...prev, isOpen: true }));
+	},
+	close: () => {
+		tableOfContentsStore.setState((prev) => ({ ...prev, isOpen: false }));
+	},
+	toggle: () => {
+		tableOfContentsStore.setState((prev) => ({
+			...prev,
+			isOpen: !prev.isOpen,
+		}));
+	},
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,3 +81,16 @@ export type ChatSendMessageFunction =
 
 export type ChatRegenerateFunction =
 	UseChatHelpers<CustomUIMessage>["regenerate"];
+
+export type TableOfContentsHeading = {
+	text: string;
+	depth: number;
+	headingId: string;
+};
+
+export type TableOfContentsSection = {
+	turnId: string;
+	userPreview: string;
+	assistantId?: string;
+	headings: TableOfContentsHeading[];
+};


### PR DESCRIPTION
Fixes #112 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsible Table of Contents for chats with quick navigation to each user turn and assistant headings. Improves long chat navigation and fixes #112.

- New Features
  - Sidebar lists each user message with a preview and nested assistant headings.
  - Desktop-only toggle shows when there are messages; sidebar slides in/out.
  - Jump to turns and headings with element IDs and instant scrolling; correct offset via `scroll-mt-6`.
  - Headings get stable IDs in `memoized-markdown.tsx` using `marked`.
  - TOC state managed via `@tanstack/store` and `@tanstack/react-store`.

- Bug Fixes
  - Toggle no longer overlaps the input and stays hidden on empty chats or when open.
  - Empty state: shows “No contents yet” when there are no user messages.
  - Fixed TS types for TOC structures and markdown components.

<sup>Written for commit ea3f3e8d2433802fe003a672e699799a3e973419. Summary will update on new commits. <a href="https://cubic.dev/pr/ankitk26/baychat/pull/114?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

