### PR TITLE
add global code block wrap toggle

### DIFF
--- a/src/components/code-highlight.tsx
+++ b/src/components/code-highlight.tsx
@@ -1,9 +1,13 @@
 import { CopyIcon, TextAlignLeftIcon } from "@phosphor-icons/react";
 import { useTheme } from "better-themes";
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import ShikiHighlighter, { type Element, isInlineCode } from "react-shiki";
 import { toast } from "sonner";
 import { cn } from "~/lib/utils";
+import {
+	appearanceStoreActions,
+	useAppearanceStore,
+} from "~/stores/appearance-store";
 import { Button } from "./ui/button";
 import { Toggle } from "./ui/toggle";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -20,7 +24,7 @@ export default function CodeHighlight({
 	node,
 }: CodeHighlightProps) {
 	const { theme } = useTheme();
-	const [isWrap, setIsWrap] = useState(false);
+	const isWrap = useAppearanceStore((s) => s.wrapCodeBlocks);
 
 	const match = className?.match(/language-(\w+)/);
 	const language = match ? match[1] : undefined;
@@ -46,7 +50,7 @@ export default function CodeHighlight({
 							render={
 								<Toggle
 									pressed={isWrap}
-									onPressedChange={setIsWrap}
+									onPressedChange={appearanceStoreActions.toggleWrapCodeBlocks}
 									size="sm"
 								/>
 							}

--- a/src/stores/appearance-store.ts
+++ b/src/stores/appearance-store.ts
@@ -3,13 +3,14 @@ import { Store } from "@tanstack/store";
 
 type AppearanceStoreState = {
 	showTokenUsage: boolean;
+	wrapCodeBlocks: boolean;
 };
 
 const STORAGE_KEY = "baychat-appearance-settings";
 
 const getInitialState = (): AppearanceStoreState => {
 	if (typeof window === "undefined") {
-		return { showTokenUsage: false };
+		return { showTokenUsage: false, wrapCodeBlocks: false };
 	}
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
@@ -19,7 +20,7 @@ const getInitialState = (): AppearanceStoreState => {
 	} catch {
 		// Ignore parse errors
 	}
-	return { showTokenUsage: false };
+	return { showTokenUsage: false, wrapCodeBlocks: false };
 };
 
 const appearanceStore = new Store<AppearanceStoreState>(getInitialState());
@@ -40,6 +41,12 @@ export const appearanceStoreActions = {
 		appearanceStore.setState((prev) => ({
 			...prev,
 			showTokenUsage: !prev.showTokenUsage,
+		}));
+	},
+	toggleWrapCodeBlocks: () => {
+		appearanceStore.setState((prev) => ({
+			...prev,
+			wrapCodeBlocks: !prev.wrapCodeBlocks,
 		}));
 	},
 };


### PR DESCRIPTION
Fixes #116 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global code block wrap toggle that applies across the app and persists between sessions. Replaces local state in CodeHighlight with the shared appearance store.

- **New Features**
  - Added `wrapCodeBlocks` to the appearance store with `toggleWrapCodeBlocks` action (defaults off).
  - Persisted the setting via the existing `baychat-appearance-settings` localStorage key.
  - Updated `CodeHighlight` to read/write wrap state from the store.

<sup>Written for commit 6d775107e400d2135d6da6567ad0f322e544400c. Summary will update on new commits. <a href="https://cubic.dev/pr/ankitk26/baychat/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

