### PR TITLE
refine app visual style

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -12,7 +12,11 @@ import AppSidebarNewChatButton from "./app-sidebar-new-chat-button";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	return (
-		<Sidebar collapsible="offcanvas" {...props}>
+		<Sidebar
+			className="border-r border-sidebar-border/70 bg-sidebar"
+			collapsible="offcanvas"
+			{...props}
+		>
 			<SidebarHeader>
 				<AppSidebarHeader />
 				<AppSidebarNewChatButton />

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -155,7 +155,7 @@ export default function Chat({
 			.find(isImageFilePart)?.url ?? null;
 
 	return (
-		<div className="relative mx-auto flex h-full min-h-0 w-full flex-col">
+		<div className="relative mx-auto flex h-full min-h-0 w-full flex-col overflow-hidden">
 			<div className="flex h-full min-h-0">
 				{/* Main chat area */}
 				<div className="relative flex-1 overflow-hidden">
@@ -167,7 +167,7 @@ export default function Chat({
 
 						{chatId && (
 							<ScrollArea className="h-full w-full" viewportRef={viewportRef}>
-								<div className="mx-auto min-h-full w-full max-w-full px-3 lg:max-w-3xl lg:px-4">
+								<div className="mx-auto min-h-full w-full max-w-full px-4 lg:max-w-5xl lg:px-10">
 									<div
 										className="pb-safe my-4 space-y-6 lg:my-8 lg:space-y-8"
 										style={{ paddingBottom: `${inputHeight + 40}px` }}
@@ -236,7 +236,7 @@ export default function Chat({
 					)}
 
 					{/* Fixed prompt input with backdrop blur */}
-					<div className="absolute right-0 bottom-0 left-0 z-10">
+					<div className="absolute right-0 bottom-0 left-0 z-10 bg-gradient-to-t from-background via-background/95 to-transparent pt-20">
 						<UserPromptInput
 							chatId={chatId}
 							latestGeneratedImageUrl={latestGeneratedImageUrl}

--- a/src/components/code-highlight.tsx
+++ b/src/components/code-highlight.tsx
@@ -41,8 +41,8 @@ export default function CodeHighlight({
 	}
 
 	return (
-		<div className="w-full max-w-full">
-			<div className="flex items-center justify-between rounded-tl-lg rounded-tr-lg bg-card-foreground/10 px-4 text-sm text-secondary-foreground dark:bg-secondary">
+		<div className="w-full max-w-full overflow-hidden rounded border border-border bg-background dark:border-border/70 dark:bg-code-dark">
+			<div className="flex items-center justify-between border-b border-border bg-card-foreground/10 px-4 text-sm text-secondary-foreground dark:border-border/70 dark:bg-secondary">
 				<span className="font-mono font-light">{language ?? "txt"}</span>
 				<div className="my-0.5 flex items-center gap-2">
 					<Tooltip>
@@ -84,7 +84,7 @@ export default function CodeHighlight({
 
 			<div
 				className={cn(
-					"w-full max-w-full rounded-br-lg rounded-bl-lg border-r border-b border-l bg-background text-xs sm:text-sm dark:border-0 dark:bg-code-dark",
+					"w-full max-w-full bg-background text-xs sm:text-sm dark:bg-code-dark",
 					isWrap ? "break-all whitespace-pre-wrap" : "overflow-x-auto",
 				)}
 			>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-	"group/button focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all outline-none select-none cursor-pointer focus-visible:ring-2 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/button focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center rounded-[calc(var(--radius)-1px)] border border-transparent bg-clip-padding font-mono text-xs/relaxed font-medium whitespace-nowrap transition-all outline-none select-none cursor-pointer focus-visible:ring-2 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground hover:bg-primary/80",
+				default: "bg-primary text-primary-foreground hover:bg-primary/85",
 				outline:
 					"border-border hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-input/30",
 				secondary:

--- a/src/components/user-prompt-input.tsx
+++ b/src/components/user-prompt-input.tsx
@@ -227,9 +227,9 @@ export default function UserPromptInput(props: Props) {
 	}, [props.chatId, isDesktop, paramsChatId]);
 
 	return (
-		<div ref={containerRef} className="bg-background/80 backdrop-blur">
+		<div ref={containerRef} className="px-4 pb-4 md:px-10 md:pb-8">
 			<form
-				className="mx-auto flex w-full max-w-full flex-col rounded-tl-lg rounded-tr-lg border border-border bg-popover/90 p-3 lg:max-w-3xl lg:p-4"
+				className="mx-auto flex w-full max-w-full flex-col border border-border bg-popover/95 p-3 shadow-[0_18px_80px_rgb(0_0_0/0.22)] backdrop-blur-xl transition-colors duration-200 focus-within:border-ring/70 lg:max-w-3xl lg:p-4"
 				onSubmit={(e) => {
 					e.preventDefault();
 					handlePromptSubmit();
@@ -244,7 +244,7 @@ export default function UserPromptInput(props: Props) {
 
 				<div className="flex-1">
 					<textarea
-						className="max-h-80 min-h-8 w-full resize-none text-sm focus:outline-none"
+						className="max-h-80 min-h-8 w-full resize-none bg-transparent text-sm leading-6 placeholder:text-muted-foreground/70 focus:outline-none"
 						disabled={
 							isSubmittingPrompt ||
 							isUploading ||
@@ -263,7 +263,7 @@ export default function UserPromptInput(props: Props) {
 						onPaste={(e) => {
 							handlePaste(e);
 						}}
-						placeholder="Start the conversation..."
+						placeholder="Message baychat..."
 						ref={textareaRef}
 						rows={1}
 						value={input}

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -39,8 +39,9 @@ function FloatingSidebarTrigger() {
 function RouteComponent() {
 	return (
 		<SidebarProvider>
-			<AppSidebar variant="inset" />
-			<SidebarInset className="h-svh overflow-hidden">
+			<div className="fixed inset-0 -z-10 bg-[radial-gradient(circle_at_50%_-20%,color-mix(in_oklch,var(--foreground)_6%,transparent),transparent_44rem)]" />
+			<AppSidebar variant="sidebar" />
+			<SidebarInset className="h-svh overflow-hidden rounded-none bg-background/92 shadow-none">
 				<FloatingSidebarTrigger />
 				<Outlet />
 			</SidebarInset>

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,42 +69,42 @@
 }
 
 :root {
-	--background: oklch(0.99 0 0);
-	--foreground: oklch(0.12 0 0);
-	--card: oklch(0.97 0 0);
-	--card-foreground: oklch(0.12 0 0);
-	--popover: oklch(0.99 0 0);
-	--popover-foreground: oklch(0.12 0 0);
-	--primary: oklch(0.12 0 0);
-	--primary-foreground: oklch(0.97 0 0);
-	--secondary: oklch(0.94 0 0);
+	--background: oklch(0.97 0 0);
+	--foreground: oklch(0.08 0 0);
+	--card: oklch(0.985 0 0);
+	--card-foreground: oklch(0.08 0 0);
+	--popover: oklch(0.985 0 0);
+	--popover-foreground: oklch(0.08 0 0);
+	--primary: oklch(0.08 0 0);
+	--primary-foreground: oklch(0.98 0 0);
+	--secondary: oklch(0.92 0 0);
 	--secondary-foreground: oklch(0.12 0 0);
-	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.44 0 0);
-	--accent: oklch(0.94 0 0);
-	--accent-foreground: oklch(0.12 0 0);
-	--destructive: oklch(0.63 0.19 23.03);
-	--destructive-foreground: oklch(0.97 0 0);
-	--border: oklch(0.92 0 0);
-	--input: oklch(0.94 0 0);
-	--ring: oklch(0.12 0 0);
+	--muted: oklch(0.93 0 0);
+	--muted-foreground: oklch(0.46 0 0);
+	--accent: oklch(0.92 0 0);
+	--accent-foreground: oklch(0.08 0 0);
+	--destructive: oklch(0.58 0.2 25);
+	--destructive-foreground: oklch(0.98 0 0);
+	--border: oklch(0.82 0 0);
+	--input: oklch(0.88 0 0);
+	--ring: oklch(0.28 0 0);
 	--chart-1: oklch(0.81 0.17 75.35);
 	--chart-2: oklch(0.55 0.22 264.53);
 	--chart-3: oklch(0.72 0 0);
 	--chart-4: oklch(0.92 0 0);
 	--chart-5: oklch(0.56 0 0);
-	--sidebar: oklch(0.99 0 0);
+	--sidebar: oklch(0.955 0 0);
 	--sidebar-foreground: oklch(0.12 0 0);
-	--sidebar-primary: oklch(0.12 0 0);
-	--sidebar-primary-foreground: oklch(0.97 0 0);
-	--sidebar-accent: oklch(0.94 0 0);
-	--sidebar-accent-foreground: oklch(0.12 0 0);
-	--sidebar-border: oklch(0.94 0 0);
-	--sidebar-ring: oklch(0.12 0 0);
+	--sidebar-primary: oklch(0.08 0 0);
+	--sidebar-primary-foreground: oklch(0.98 0 0);
+	--sidebar-accent: oklch(0.9 0 0);
+	--sidebar-accent-foreground: oklch(0.08 0 0);
+	--sidebar-border: oklch(0.82 0 0);
+	--sidebar-ring: oklch(0.28 0 0);
 	--font-sans: "Geist Variable", sans-serif;
 	--font-serif: Georgia, serif;
 	--font-mono: "Geist Mono Variable", monospace;
-	--radius: 0.625rem;
+	--radius: 0.25rem;
 	--shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
 	--shadow-xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
 	--shadow-sm:
@@ -122,38 +122,38 @@
 }
 
 .dark {
-	--background: oklch(0.08 0 0);
-	--foreground: oklch(0.97 0 0);
-	--card: oklch(0.14 0 0);
-	--card-foreground: oklch(0.97 0 0);
-	--popover: oklch(0.18 0 0);
-	--popover-foreground: oklch(0.97 0 0);
-	--primary: oklch(0.97 0 0);
-	--primary-foreground: oklch(0.08 0 0);
-	--secondary: oklch(0.25 0 0);
-	--secondary-foreground: oklch(0.97 0 0);
-	--muted: oklch(0.23 0 0);
-	--muted-foreground: oklch(0.72 0 0);
-	--accent: oklch(0.32 0 0);
-	--accent-foreground: oklch(0.97 0 0);
-	--destructive: oklch(0.69 0.2 23.91);
-	--destructive-foreground: oklch(0.08 0 0);
-	--border: oklch(0.26 0 0);
-	--input: oklch(0.32 0 0);
-	--ring: oklch(0.72 0 0);
+	--background: oklch(0.035 0 0);
+	--foreground: oklch(0.93 0 0);
+	--card: oklch(0.075 0 0);
+	--card-foreground: oklch(0.93 0 0);
+	--popover: oklch(0.075 0 0);
+	--popover-foreground: oklch(0.93 0 0);
+	--primary: oklch(0.93 0 0);
+	--primary-foreground: oklch(0.035 0 0);
+	--secondary: oklch(0.12 0 0);
+	--secondary-foreground: oklch(0.93 0 0);
+	--muted: oklch(0.12 0 0);
+	--muted-foreground: oklch(0.58 0 0);
+	--accent: oklch(0.16 0 0);
+	--accent-foreground: oklch(0.93 0 0);
+	--destructive: oklch(0.62 0.2 25);
+	--destructive-foreground: oklch(0.96 0 0);
+	--border: oklch(0.2 0 0);
+	--input: oklch(0.16 0 0);
+	--ring: oklch(0.62 0.17 45);
 	--chart-1: oklch(0.81 0.17 75.35);
 	--chart-2: oklch(0.58 0.21 260.84);
 	--chart-3: oklch(0.56 0 0);
 	--chart-4: oklch(0.44 0 0);
 	--chart-5: oklch(0.92 0 0);
-	--sidebar: oklch(0.18 0 0);
-	--sidebar-foreground: oklch(0.97 0 0);
-	--sidebar-primary: oklch(0.97 0 0);
-	--sidebar-primary-foreground: oklch(0.08 0 0);
-	--sidebar-accent: oklch(0.32 0 0);
-	--sidebar-accent-foreground: oklch(0.97 0 0);
-	--sidebar-border: oklch(0.32 0 0);
-	--sidebar-ring: oklch(0.72 0 0);
+	--sidebar: oklch(0.055 0 0);
+	--sidebar-foreground: oklch(0.84 0 0);
+	--sidebar-primary: oklch(0.93 0 0);
+	--sidebar-primary-foreground: oklch(0.035 0 0);
+	--sidebar-accent: oklch(0.11 0 0);
+	--sidebar-accent-foreground: oklch(0.93 0 0);
+	--sidebar-border: oklch(0.18 0 0);
+	--sidebar-ring: oklch(0.62 0.17 45);
 	--shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
 	--shadow-xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
 	--shadow-sm:
@@ -176,8 +176,26 @@
 		@apply border-border outline-ring/50;
 	}
 	body {
-		@apply bg-background text-foreground;
-		@apply bg-background text-foreground;
+		@apply bg-background text-foreground antialiased;
+		background-image:
+			radial-gradient(
+				circle at 50% -10%,
+				color-mix(in oklch, var(--foreground) 7%, transparent),
+				transparent 42rem
+			),
+			linear-gradient(
+				color-mix(in oklch, var(--foreground) 3%, transparent) 1px,
+				transparent 1px
+			),
+			linear-gradient(
+				90deg,
+				color-mix(in oklch, var(--foreground) 3%, transparent) 1px,
+				transparent 1px
+			);
+		background-size:
+			auto,
+			24px 24px,
+			24px 24px;
 	}
 	html {
 		@apply font-mono;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines the app’s visual style with new light/dark palettes, smaller radii, and a subtle grid/radial background. Improves chat layout, sidebar, code blocks, buttons, and the prompt input for better contrast and readability.

- **Refactors**
  - Updated theme tokens (light/dark), borders, and rings; set `--radius` to 0.25rem for a tighter look.
  - Added global radial glow and faint grid background; body antialiasing; background layer injected in `_auth.tsx`.
  - Sidebar now uses bordered styling and `variant="sidebar"`; improved overflow handling; chat content widened to `lg:max-w-5xl` with increased padding.
  - Prompt input now sits on a gradient backdrop with blur, shadow, and focus ring; refined spacing; placeholder changed to “Message baychat...”.
  - Code blocks wrapped in a bordered container with dark mode tweaks; buttons use `font-mono`, adjusted rounding, and subtler hover.

<sup>Written for commit 82a6e0e78cee4daf27f98c39c0e4d7385854a6c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ankitk26/baychat/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

