### PR TITLE
add monthly trial messaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@ VITE_CONVEX_URL=https://example.convex.cloud
 VITE_CONVEX_SITE_URL=https://example.convex.site
 VITE_SITE_URL=http://localhost:3000
 
-GOOGLE_GENERATIVE_AI_API_KEY=***
 ANTHROPIC_API_KEY=***
+# Server-only key used for the monthly trial allowance
+OPENROUTER_TRIAL_API_KEY=***
 
 BETTER_AUTH_SECRET=***
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as messages from "../messages.js";
 import type * as migrations from "../migrations.js";
 import type * as model_chats from "../model/chats.js";
 import type * as model_users from "../model/users.js";
+import type * as trial from "../trial.js";
 
 import type {
   ApiFromModules,
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   "model/chats": typeof model_chats;
   "model/users": typeof model_users;
+  trial: typeof trial;
 }>;
 
 /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -67,6 +67,17 @@ export default defineSchema({
 		tokens: v.float64(),
 	}).index("by_user_and_model", ["userId", "model"]),
 
+	trialUsage: defineTable({
+		userId: v.id("users"),
+		// Kept for compatibility with the original monthly trial records.
+		month: v.string(),
+		messages: v.number(),
+		periodStartedAt: v.optional(v.number()),
+		resetAt: v.optional(v.number()),
+	})
+		.index("by_user_and_month", ["userId", "month"])
+		.index("by_user", ["userId"]),
+
 	imageGenerations: defineTable({
 		userId: v.id("users"),
 		storageId: v.id("_storage"),

--- a/convex/trial.ts
+++ b/convex/trial.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+import { trialModelIds } from "../src/constants/model-providers";
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, query, type QueryCtx } from "./_generated/server";
+import { getAuthUserIdOrThrow } from "./model/users";
+
+export const TRIAL_MESSAGE_LIMIT = 5;
+const TRIAL_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;
+
+const getUsageDoc = async (ctx: QueryCtx, userId: Id<"users">) =>
+	ctx.db
+		.query("trialUsage")
+		.withIndex("by_user", (q) => q.eq("userId", userId))
+		.order("desc")
+		.first();
+
+const getActiveUsage = (usage: Doc<"trialUsage"> | null, now: number) => {
+	if (!usage?.resetAt || usage.resetAt <= now) return null;
+	return usage;
+};
+
+export const getUsage = query({
+	handler: async (ctx) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		const now = Date.now();
+		const usage = getActiveUsage(await getUsageDoc(ctx, userId), now);
+
+		return {
+			used: usage?.messages ?? 0,
+			limit: TRIAL_MESSAGE_LIMIT,
+			remaining: Math.max(0, TRIAL_MESSAGE_LIMIT - (usage?.messages ?? 0)),
+			resetAt: usage?.resetAt ?? null,
+		};
+	},
+});
+
+export const releaseMessage = mutation({
+	args: { periodStartedAt: v.number() },
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		const usage = await getUsageDoc(ctx, userId);
+
+		// Do not refund a failed request into a newer 30-day period.
+		if (usage?.periodStartedAt === args.periodStartedAt && usage.messages > 0) {
+			await ctx.db.patch(usage._id, { messages: usage.messages - 1 });
+		}
+	},
+});
+
+export const reserveMessage = mutation({
+	args: { modelId: v.string() },
+	handler: async (ctx, args) => {
+		const userId = await getAuthUserIdOrThrow(ctx);
+		if (!(trialModelIds as readonly string[]).includes(args.modelId)) {
+			throw new Error(`Model ${args.modelId} is not available in the trial`);
+		}
+
+		const now = Date.now();
+		const usage = await getUsageDoc(ctx, userId);
+		const activeUsage = getActiveUsage(usage, now);
+		const used = activeUsage?.messages ?? 0;
+		if (used >= TRIAL_MESSAGE_LIMIT && activeUsage) {
+			const resetAt = activeUsage.resetAt as number;
+			throw new Error(
+				`You've used all 5 free messages. Your trial resets on ${new Date(resetAt).toISOString().slice(0, 10)}.`,
+			);
+		}
+
+		const periodStartedAt = activeUsage?.periodStartedAt ?? now;
+		const resetAt = activeUsage?.resetAt ?? now + TRIAL_PERIOD_MS;
+		if (usage) {
+			await ctx.db.patch(usage._id, {
+				month: new Date(periodStartedAt).toISOString(),
+				messages: used + 1,
+				periodStartedAt,
+				resetAt,
+			});
+		} else {
+			await ctx.db.insert("trialUsage", {
+				userId,
+				month: new Date(periodStartedAt).toISOString(),
+				messages: 1,
+				periodStartedAt,
+				resetAt,
+			});
+		}
+
+		return { remaining: TRIAL_MESSAGE_LIMIT - used - 1, periodStartedAt };
+	},
+});

--- a/readme.md
+++ b/readme.md
@@ -121,8 +121,8 @@ It supports multiple AI providers, real-time messaging, and chat organization.
    GOOGLE_CLIENT_SECRET=your_google_client_secret
 
    # Optional: API keys for AI providers
-   GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key
    ANTHROPIC_API_KEY=your_anthropic_api_key
+   OPENROUTER_TRIAL_API_KEY=your_openrouter_api_key
    ```
 
 5. Run the development server:
@@ -136,7 +136,7 @@ It supports multiple AI providers, real-time messaging, and chat organization.
 ## Usage
 
 1. Sign in with your GitHub or Google account
-2. Configure API keys in settings (optional - you can use OpenRouter for all models)
+2. Configure API keys in settings (optional - new users receive 5 trial messages per month)
 3. Start chatting with any available AI model
 4. Organize chats by creating folders and pinning important conversations
 

--- a/src/components/model-selector.tsx
+++ b/src/components/model-selector.tsx
@@ -1,5 +1,8 @@
+import { convexQuery } from "@convex-dev/react-query";
 import { CaretDownIcon, KeyIcon } from "@phosphor-icons/react";
 import { useHotkey } from "@tanstack/react-hotkeys";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "convex/_generated/api";
 import { useCallback, useState } from "react";
 import { getAccessibleModels } from "~/lib/get-accessible-models";
 import { modelStoreActions, useModelStore } from "~/stores/model-store";
@@ -32,7 +35,18 @@ export default function ModelSelector() {
 		persistedApiKeys,
 		persistedUseOpenRouter,
 	);
-
+	const hasOwnKey = persistedUseOpenRouter
+		? persistedApiKeys.openrouter.trim() !== ""
+		: [
+				persistedApiKeys.gemini,
+				persistedApiKeys.openai,
+				persistedApiKeys.anthropic,
+				persistedApiKeys.xai,
+			].some((key) => key.trim() !== "");
+	const { data: trialUsage } = useQuery({
+		...convexQuery(api.trial.getUsage, {}),
+		enabled: !hasOwnKey,
+	});
 	const handleHotkey = useCallback(() => setOpen(true), []);
 	useHotkey("Mod+/", handleHotkey);
 
@@ -40,6 +54,11 @@ export default function ModelSelector() {
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger render={<Button variant="outline" />}>
 				{selectedModel.name}
+				{!hasOwnKey && trialUsage && (
+					<span className="ml-1 text-[11px] text-muted-foreground">
+						{trialUsage.remaining} free left
+					</span>
+				)}
 				<CaretDownIcon />
 			</DropdownMenuTrigger>
 			<DropdownMenuContent className="w-60">

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,7 +1,4 @@
-"use client";
-
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
-import * as React from "react";
 import { cn } from "~/lib/utils";
 
 function ScrollArea({

--- a/src/constants/model-providers.ts
+++ b/src/constants/model-providers.ts
@@ -11,24 +11,6 @@ const geminiModels = {
 	models: [
 		defaultSelectedModel,
 		{
-			name: "Gemini 2.5 Pro",
-			openRouterModelId: "google/gemini-2.5-pro",
-			modelId: "gemini-2.5-pro",
-			isFree: false,
-		},
-		{
-			name: "Gemini 3 Flash",
-			openRouterModelId: "google/gemini-3-flash-preview",
-			modelId: "gemini-3-flash-preview",
-			isFree: false,
-		},
-		{
-			name: "Gemini 3 Pro",
-			openRouterModelId: "google/gemini-3-pro-preview",
-			modelId: "gemini-3-pro-preview",
-			isFree: false,
-		},
-		{
 			name: "Gemini 3.1 Pro",
 			openRouterModelId: "google/gemini-3.1-pro-preview",
 			modelId: "gemini-3.1-pro-preview",
@@ -84,21 +66,9 @@ const deepseekModels = {
 	key: "deepseek",
 	models: [
 		{
-			name: "DeepSeek R1 0528",
-			openRouterModelId: "deepseek/deepseek-r1-0528",
-			modelId: "deepseek/deepseek-r1-0528",
-			isFree: false,
-		},
-		{
 			name: "DeepSeek R1",
 			openRouterModelId: "deepseek/deepseek-r1",
 			modelId: "deepseek/deepseek-r1",
-			isFree: false,
-		},
-		{
-			name: "DeepSeek V3 (0324)",
-			openRouterModelId: "deepseek/deepseek-chat-v3-0324",
-			modelId: "deepseek/deepseek-chat-v3-0324",
 			isFree: false,
 		},
 		{
@@ -132,60 +102,6 @@ const openAiModels = {
 	provider: "OpenAI",
 	key: "openai",
 	models: [
-		{
-			name: "o3",
-			openRouterModelId: "openai/o3",
-			modelId: "o3",
-			isFree: false,
-		},
-		{
-			name: "o3 Mini",
-			openRouterModelId: "openai/o3-mini",
-			modelId: "o3-mini",
-			isFree: false,
-		},
-		{
-			name: "o4",
-			openRouterModelId: "openai/gpt-4o-mini",
-			modelId: "gpt-4o-mini",
-			isFree: false,
-		},
-		{
-			name: "o4 Mini",
-			openRouterModelId: "openai/gpt-4o",
-			modelId: "gpt-4o",
-			isFree: false,
-		},
-		{
-			name: "GPT 5",
-			openRouterModelId: "openai/gpt-5",
-			modelId: "gpt-5",
-			isFree: false,
-		},
-		{
-			name: "GPT 5 mini",
-			openRouterModelId: "openai/gpt-5-mini",
-			modelId: "gpt-5-mini",
-			isFree: false,
-		},
-		{
-			name: "GPT 5 nano",
-			openRouterModelId: "openai/gpt-5-nano",
-			modelId: "gpt-5-nano",
-			isFree: false,
-		},
-		{
-			name: "GPT 5.2",
-			openRouterModelId: "openai/gpt-5.2",
-			modelId: "gpt-5.2",
-			isFree: false,
-		},
-		{
-			name: "GPT 5.3 Codex",
-			openRouterModelId: "openai/gpt-5.3-codex",
-			modelId: "gpt-5.3-codex",
-			isFree: false,
-		},
 		{
 			name: "GPT 5.4",
 			openRouterModelId: "openai/gpt-5.4",
@@ -254,33 +170,9 @@ const anthropicModels = {
 	key: "anthropic",
 	models: [
 		{
-			name: "Claude 3.5 Sonnet",
-			openRouterModelId: "anthropic/claude-3.5-sonnet",
-			modelId: "claude-3-5-sonnet-latest",
-			isFree: false,
-		},
-		{
-			name: "Claude 3.7 Sonnet",
-			openRouterModelId: "anthropic/claude-3.7-sonnet",
-			modelId: "claude-3-7-sonnet-latest",
-			isFree: false,
-		},
-		{
-			name: "Claude Sonnet 4",
-			openRouterModelId: "anthropic/claude-sonnet-4",
-			modelId: "claude-sonnet-4-0",
-			isFree: false,
-		},
-		{
-			name: "Claude Opus 4",
-			openRouterModelId: "anthropic/claude-opus-4",
-			modelId: "claude-opus-4-0",
-			isFree: false,
-		},
-		{
-			name: "Claude Opus 4.5",
-			openRouterModelId: "anthropic/claude-opus-4.5",
-			modelId: "claude-opus-4-5",
+			name: "Claude 3 Haiku",
+			openRouterModelId: "anthropic/claude-3-haiku",
+			modelId: "claude-3-haiku-20240307",
 			isFree: false,
 		},
 		{
@@ -333,12 +225,6 @@ const xAiModels = {
 	key: "xai",
 	models: [
 		{
-			name: "Grok 4",
-			openRouterModelId: "x-ai/grok-4",
-			modelId: "grok-4",
-			isFree: false,
-		},
-		{
 			name: "Grok 4 Fast",
 			openRouterModelId: "x-ai/grok-4-fast",
 			modelId: "grok-4-fast-non-reasoning",
@@ -375,18 +261,6 @@ const moonshotModels = {
 	provider: "Moonshot",
 	key: "moonshot",
 	models: [
-		{
-			name: "Kimi K2",
-			openRouterModelId: "moonshotai/kimi-k2",
-			modelId: "moonshotai/kimi-k2",
-			isFree: false,
-		},
-		{
-			name: "Kimi K2 Thinking",
-			openRouterModelId: "moonshotai/kimi-k2-thinking",
-			modelId: "moonshotai/kimi-k2-thinking",
-			isFree: false,
-		},
 		{
 			name: "Kimi K2.5",
 			openRouterModelId: "moonshotai/kimi-k2.5",
@@ -544,3 +418,13 @@ export const allModelProviders = [
 	xiaomiModels,
 	byteDanceModels,
 ] as const;
+
+type AvailableOpenRouterModelId =
+	(typeof allModelProviders)[number]["models"][number]["openRouterModelId"];
+
+export const trialModelIds = [
+	"google/gemini-2.5-flash",
+	"google/gemini-2.5-flash-image",
+	"openai/gpt-5.4-nano",
+	"moonshotai/kimi-k2.5",
+] as const satisfies readonly AvailableOpenRouterModelId[];

--- a/src/lib/get-accessible-models.ts
+++ b/src/lib/get-accessible-models.ts
@@ -1,4 +1,4 @@
-import { allModelProviders } from "~/constants/model-providers";
+import { allModelProviders, trialModelIds } from "~/constants/model-providers";
 import type {
 	ApiKeys,
 	ModelWithAvailability,
@@ -11,6 +11,14 @@ export function getAccessibleModels(
 ): ProviderGroupWithAvailability[] {
 	const resultProviderGroups: ProviderGroupWithAvailability[] = [];
 
+	const hasAnyProviderKey = [
+		apiKeys.gemini,
+		apiKeys.openai,
+		apiKeys.anthropic,
+		apiKeys.xai,
+	].some((key) => key.trim() !== "");
+	const trialModelIdSet = new Set<string>(trialModelIds);
+
 	for (const group of allModelProviders) {
 		const modelsWithAvailability: ModelWithAvailability[] = [];
 
@@ -19,7 +27,10 @@ export function getAccessibleModels(
 
 			// Primary check: If useOpenRouter toggle is ON, all models are available.
 			if (useOpenRouter) {
-				available = true;
+				available =
+					apiKeys.openrouter.trim() !== "" ||
+					(!apiKeys.openrouter.trim() &&
+						trialModelIdSet.has(model.openRouterModelId));
 			} else {
 				// If useOpenRouter toggle is OFF, availability depends on individual provider keys or if the model is free.
 				let hasSpecificProviderKey = false;
@@ -40,7 +51,9 @@ export function getAccessibleModels(
 						hasSpecificProviderKey = false;
 				}
 				// A model is available if a specific provider key is present (for paid models) OR the model is free.
-				available = hasSpecificProviderKey || model.isFree;
+				available =
+					hasSpecificProviderKey ||
+					(!hasAnyProviderKey && trialModelIdSet.has(model.openRouterModelId));
 			}
 
 			modelsWithAvailability.push({

--- a/src/routes/api.chat.ts
+++ b/src/routes/api.chat.ts
@@ -15,23 +15,52 @@ import {
 } from "ai";
 import type { FileUIPart, UIMessagePart, UIDataTypes, UITools } from "ai";
 import { api } from "convex/_generated/api";
-import { defaultSelectedModel } from "~/constants/model-providers";
 import { systemMessage } from "~/constants/system-message";
 import { fetchAuthMutation } from "~/lib/auth-server";
 import { generateRandomUUID } from "~/lib/generate-random-uuid";
 import { getAuthUser } from "~/server-fns/get-auth";
 import type { ApiKeys, CustomUIMessage, Model } from "~/types";
 
+const hasOwnKeyForRequest = (
+	apiKeys: ApiKeys,
+	model: Model,
+	useOpenRouter: boolean,
+) => {
+	if (useOpenRouter) return apiKeys.openrouter.trim() !== "";
+	if (model.openRouterModelId.startsWith("google")) {
+		return apiKeys.gemini.trim() !== "";
+	}
+	if (model.openRouterModelId.startsWith("openai")) {
+		return apiKeys.openai.trim() !== "";
+	}
+	if (model.openRouterModelId.startsWith("anthropic")) {
+		return apiKeys.anthropic.trim() !== "";
+	}
+	if (model.openRouterModelId.startsWith("x-ai")) {
+		return apiKeys.xai.trim() !== "";
+	}
+	return false;
+};
+
 const resolveModelForRequest = (
 	requestModel: Model,
 	apiKeys: ApiKeys,
 	useOpenRouter: boolean,
 	isWebSearchEnabled: boolean,
+	isTrial: boolean,
 ) => {
-	const geminiProvider = createGoogleGenerativeAI({
-		apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-	});
-	const defaultModel = geminiProvider(defaultSelectedModel.modelId);
+	if (isTrial) {
+		const trialKey = process.env.OPENROUTER_TRIAL_API_KEY;
+		if (!trialKey) {
+			throw new Error("Trial messaging is not configured.");
+		}
+		const openRouter = createOpenRouter({ apiKey: trialKey });
+		return openRouter.chat(
+			isWebSearchEnabled
+				? `${requestModel.openRouterModelId}:online`
+				: requestModel.openRouterModelId,
+		);
+	}
 
 	if (useOpenRouter && apiKeys.openrouter.trim() !== "") {
 		const openRouter = createOpenRouter({ apiKey: apiKeys.openrouter });
@@ -44,7 +73,7 @@ const resolveModelForRequest = (
 	if (!useOpenRouter) {
 		if (requestModel.openRouterModelId.startsWith("google")) {
 			if (apiKeys.gemini.trim() === "") {
-				return defaultModel;
+				throw new Error("API Key for Google is not provided.");
 			}
 			return createGoogleGenerativeAI({ apiKey: apiKeys.gemini })(
 				requestModel.modelId,
@@ -75,7 +104,7 @@ const resolveModelForRequest = (
 		}
 	}
 
-	return defaultModel;
+	throw new Error("No API key is configured for this model provider.");
 };
 
 const FAILED_UPLOAD_PLACEHOLDER =
@@ -268,13 +297,75 @@ export const Route = createFileRoute("/api/chat")({
 					chatId,
 					customSystemPrompt,
 				} = chatRequestBody;
-
-				const modelToUse = resolveModelForRequest(
-					requestModel,
+				const hasOwnKey = hasOwnKeyForRequest(
 					apiKeys,
+					requestModel,
 					useOpenRouter,
-					isWebSearchEnabled,
 				);
+				const isTrial = !hasOwnKey;
+
+				if (isTrial && !process.env.OPENROUTER_TRIAL_API_KEY) {
+					throw new Error("Trial messaging is not configured.");
+				}
+
+				let trialMessageReleased = false;
+				let trialPeriodStartedAt: number | undefined;
+				const releaseTrialMessage = () => {
+					if (
+						!isTrial ||
+						trialMessageReleased ||
+						trialPeriodStartedAt === undefined
+					)
+						return;
+					trialMessageReleased = true;
+					void fetchAuthMutation(api.trial.releaseMessage, {
+						periodStartedAt: trialPeriodStartedAt,
+					});
+				};
+
+				if (isTrial) {
+					try {
+						const reservation = await fetchAuthMutation(
+							api.trial.reserveMessage,
+							{ modelId: requestModel.openRouterModelId },
+						);
+						trialPeriodStartedAt = reservation.periodStartedAt;
+					} catch (error) {
+						const errorMessage = error instanceof Error ? error.message : "";
+						const resetDate = errorMessage.match(
+							/Your trial resets on (\d{4}-\d{2}-\d{2})\./,
+						)?.[1];
+						const formattedResetDate = resetDate
+							? new Intl.DateTimeFormat("en-US", {
+									month: "long",
+									day: "numeric",
+									year: "numeric",
+									timeZone: "UTC",
+								}).format(new Date(`${resetDate}T00:00:00Z`))
+							: null;
+						const message = errorMessage.includes("free messages")
+							? `You've used all 5 free messages. Your trial resets on ${formattedResetDate ?? "your next reset date"}. Add your own API key to keep chatting.`
+							: errorMessage || "Your free trial messages are unavailable.";
+						return new Response(message, {
+							status: 429,
+							headers: { "Content-Type": "text/plain; charset=utf-8" },
+						});
+					}
+				}
+
+				let modelToUse;
+				try {
+					modelToUse = resolveModelForRequest(
+						requestModel,
+						apiKeys,
+						useOpenRouter,
+						isWebSearchEnabled,
+						isTrial,
+					);
+				} catch (error) {
+					releaseTrialMessage();
+					throw error;
+				}
 
 				const finalSystemMessage = customSystemPrompt
 					? `${systemMessage}\n\n${customSystemPrompt}`
@@ -342,6 +433,7 @@ export const Route = createFileRoute("/api/chat")({
 							});
 						},
 						onError: (error) => {
+							releaseTrialMessage();
 							console.error("toUIMessageStream error:", error);
 							return (error as any).message;
 						},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a monthly trial: users without their own API keys get 5 free messages every 30 days on selected models via OpenRouter. Tracks usage in Convex and shows remaining trial messages in the model selector.

- **New Features**
  - Server-side trial tracking with `trialUsage` table and Convex functions `trial.getUsage`, `trial.reserveMessage`, `trial.releaseMessage` (5-message limit, 30-day reset).
  - Chat API routes trial requests through OpenRouter using `OPENROUTER_TRIAL_API_KEY`; restricts to `trialModelIds`; releases reservations on errors; own keys bypass trial.
  - UI shows “X free left” in the model selector when no user keys are set; model availability exposes only trial-eligible models without keys.

- **Migration**
  - Add `OPENROUTER_TRIAL_API_KEY` to server env.
  - Deploy Convex schema to create `trialUsage`.
  - The default Google fallback was removed; without keys, only trial models are available.

<sup>Written for commit 4b617307ea6f4977a0a6faacefd38e8664e9fe6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ankitk26/baychat/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

